### PR TITLE
Make back to cases link remember state params.

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/controllers.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers.js
@@ -56,10 +56,8 @@
     }]);
 
   angular.module('cla.controllers')
-  .controller('CaseDetailCtrl', ['$rootScope', '$window', '$scope', 'History', 'case',
-      function($rootScope, $window, $scope, History, $case){
-        $scope.case = $case;
-
+    .controller('LayoutCtrl', ['$rootScope', '$scope', '$window', 'History',
+      function($rootScope, $scope, $window, History){
         var offStateChange = $rootScope.$on('$stateChangeSuccess', function(event, to, toParams, from, fromParams){
           if (from.name === 'case_list') {
             History.caseListStateParams = fromParams;
@@ -71,6 +69,12 @@
           offStateChange();
         });
 
+      }]);
+
+  angular.module('cla.controllers')
+  .controller('CaseDetailCtrl', ['$scope', 'case',
+      function($scope, $case){
+        $scope.case = $case;
       }]);
 
   angular.module('cla.controllers')

--- a/cla_frontend/assets-src/javascripts/app/js/services/history.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/history.js
@@ -1,6 +1,9 @@
 (function () {
   'use strict';
-
+  // this is not really required yet but is being used as a central place
+  // to hold historic state params. The idea is for this to save itself
+  // into localStorage so even if user refreshes the page the back links
+  // will go back to the right place.
   angular.module('cla.services')
     .factory('History', [function() {
       return {};

--- a/cla_frontend/assets-src/javascripts/app/js/states.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states.js
@@ -5,6 +5,7 @@
   states.Layout = {
     abstract: true,
     templateUrl: '/static/javascripts/app/partials/base.html',
+    controller: 'LayoutCtrl'
   };
 
   states.CaseListState = {


### PR DESCRIPTION
This moves them back to to LayoutCtrl level. We moved them down to just the controller that needed them before but this caused issues as the event handler was removed after a Ctrl was destroyed so it wasn't available for when that Ctrl was realoaded.
