### PR TITLE
Feature/cla eventlog: make cla frontend use nested resources.

### DIFF
--- a/cla_frontend/apps/call_centre/views.py
+++ b/cla_frontend/apps/call_centre/views.py
@@ -8,7 +8,7 @@ from api.client import get_connection
 from cla_auth.utils import call_centre_zone_required
 from django.views.decorators.csrf import csrf_exempt
 
-from legalaid.shortcuts import get_case_or_404
+from legalaid.shortcuts import get_case_or_404, get_eligibility_or_404
 
 from cla_common.templatetags.means_summary_tags import MeansSummaryFormatter
 from proxy.views import proxy_view
@@ -22,8 +22,7 @@ def dashboard(request):
 @call_centre_zone_required
 def case_means_summary(request, case_reference):
     client = get_connection(request)
-    case = get_case_or_404(client, case_reference)
-    eligibility_check = client.eligibility_check(case['eligibility_check']).get()
+    eligibility_check = get_eligibility_or_404(client, case_reference)
 
     formatter = MeansSummaryFormatter()
     output = formatter.format(eligibility_check)

--- a/cla_frontend/apps/legalaid/shortcuts.py
+++ b/cla_frontend/apps/legalaid/shortcuts.py
@@ -15,3 +15,15 @@ def get_case_or_404(client, case_reference):
         if e.response.status_code == 404:
             raise Http404('No case matches with reference %s.' % case_reference)
         raise e
+
+def get_eligibility_or_404(client, case_reference):
+    """
+    Returns the eligibility_check for case object with reference ``case_reference`` if it exists,
+    raises Http404 otherwise.
+    """
+    try:
+        return client.case(case_reference).eligibility_check.get()
+    except HttpClientError as e:
+        if e.response.status_code == 404:
+            raise Http404('No eligibility check for case with reference %s.' % case_reference)
+        raise e

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/eligibility_check.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/eligibility_check.js
@@ -38,14 +38,8 @@
           };
 
           $scope.save = function() {
-            $scope.eligibility_check.$update(function (data) {
-              if (!$scope.case.eligibility_check) {
-                $scope.case.$associate_eligibility_check(data.reference, function () {
-                  $scope.case.eligibility_check = data.reference;
-                });
-              }
-
-              $scope.eligibility_check.validate().then(function (resp) {
+            $scope.eligibility_check.$update($scope.case.reference, function () {
+              $scope.eligibility_check.validate($scope.case.reference).then(function (resp) {
                 $scope.warnings = resp.data.warnings;
               });
             });

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/personal_details.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/personal_details.js
@@ -72,22 +72,18 @@
               $scope.adaptations.language = 'WELSH';
             }
             // save personal details
-            $scope.personal_details.$update(function (data) {
+            $scope.personal_details.$update($scope.case.reference, function (data) {
               if (!$scope.case.personal_details) {
-                $scope.case.$associate_personal_details(data.reference, function () {
-                  $scope.case.personal_details = data.reference;
-                });
+                $scope.case.personal_details = data.reference;
               }
             }, function(response){
               form_utils.ctrlFormErrorCallback($scope, response, form);
               $scope.personal_details = personal_details;
             });
             // save adaptations
-            $scope.adaptations.$update(function (data) {
+            $scope.adaptations.$update($scope.case.reference, function (data) {
               if (!$scope.case.adaptation_details) {
-                $scope.case.$associate_adaptation_details(data.reference, function () {
-                  $scope.case.adaptation_details = data.reference;
-                });
+                $scope.case.adaptation_details = data.reference;
               }
             }, function(response){
               form_utils.ctrlFormErrorCallback($scope, response, form);
@@ -97,11 +93,9 @@
           };
 
           $scope.saveThirdParty = function(form) {
-            $scope.third_party.$update(function (data) {
+            $scope.third_party.$update($scope.case.reference, function (data) {
               if (!$scope.case.thirdparty_details) {
-                $scope.case.$associate_thirdparty_details(data.reference, function () {
-                  $scope.case.thirdparty_details = data.reference;
-                });
+                $scope.case.thirdparty_details = data.reference;
               }
             }, function(response){
               form_utils.ctrlFormErrorCallback($scope, response, form);

--- a/cla_frontend/assets-src/javascripts/app/js/services/models.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/models.js
@@ -74,12 +74,6 @@
         return $http.post(url, data).success(successCallback);
       };
 
-      resource.prototype.$associate_eligibility_check = function(reference, successCallback) {
-        var data = {reference: reference},
-            url = '/call_centre/proxy/case/'+this.reference+'/associate_eligibility_check/';
-        return $http.post(url, data).success(successCallback);
-      };
-
       resource.prototype.$associate_thirdparty_details = function(reference, successCallback) {
         var data = {reference: reference},
             url = '/call_centre/proxy/case/'+this.reference+'/associate_thirdparty_details/';
@@ -111,22 +105,23 @@
     .factory('EligibilityCheck', ['$http', '$resource', function($http, $resource) {
       var that = this, resource;
 
-      this.BASE_URL = '/call_centre/proxy/eligibility_check/';
+      this.BASE_URL = '/call_centre/proxy/case/:case_reference/eligibility_check/';
 
-      resource = $resource(this.BASE_URL + ':ref/', {ref: '@reference'}, {
+      resource = $resource(this.BASE_URL, {case_reference: '@case_reference'}, {
         'patch': {method: 'PATCH'}
       });
 
-      resource.prototype.$update = function(success, fail){
+      resource.prototype.$update = function(case_reference, success, fail){
         if (this.reference) {
-          return this.$patch(success, fail);
+          return this.$patch({case_reference: case_reference}, success, fail);
         } else {
-          return this.$save(success, fail);
+          return this.$save({case_reference: case_reference}, success, fail);
         }
       };
 
-      resource.prototype.validate = function() {
-        return $http.get(that.BASE_URL+this.reference+'/validate/');
+      resource.prototype.validate = function(case_reference) {
+        return $http.get(that.BASE_URL
+          .replace(':case_reference', case_reference)+'validate/');
       };
 
       resource.prototype.isEligibilityTrue = function() {
@@ -143,15 +138,15 @@
 
   angular.module('cla.services')
     .factory('PersonalDetails', ['$resource', function($resource) {
-      var resource = $resource('/call_centre/proxy/personal_details/:ref/', {ref:'@reference'}, {
+      var resource = $resource('/call_centre/proxy/case/:case_reference/personal_details/', {case_reference:'@case_reference'}, {
         'patch': {method: 'PATCH'}
       });
 
-      resource.prototype.$update = function(success, fail){
+      resource.prototype.$update = function(case_reference, success, fail){
         if (this.reference) {
-          return this.$patch(success, fail);
+          return this.$patch({case_reference: case_reference}, success, fail);
         } else {
-          return this.$save(success, fail);
+          return this.$save({case_reference: case_reference}, success, fail);
         }
       };
 
@@ -160,15 +155,15 @@
 
   angular.module('cla.services')
     .factory('Adaptations', ['$resource', function($resource) {
-      var resource = $resource('/call_centre/proxy/adaptation_details/:ref/', {ref:'@reference'}, {
+      var resource = $resource('/call_centre/proxy/case/:case_reference/adaptation_details/', {case_reference:'@case_reference'}, {
         'patch': {method: 'PATCH'}
       });
 
-      resource.prototype.$update = function(success, fail){
+      resource.prototype.$update = function(case_reference, success, fail){
         if (this.reference) {
-          return this.$patch(success, fail);
+          return this.$patch({case_reference: case_reference}, success, fail);
         } else {
-          return this.$save(success, fail);
+          return this.$save({case_reference: case_reference},success, fail);
         }
       };
 
@@ -177,15 +172,15 @@
 
   angular.module('cla.services')
     .factory('ThirdParty', ['$resource', function($resource) {
-      var resource = $resource('/call_centre/proxy/thirdparty_details/:ref/', {ref:'@reference'}, {
+      var resource = $resource('/call_centre/proxy/case/:case_reference/thirdparty_details/', {case_reference:'@case_reference'}, {
         'patch': {method: 'PATCH'}
       });
 
-      resource.prototype.$update = function(success, fail){
+      resource.prototype.$update = function(case_reference, success, fail){
         if (this.reference) {
-          return this.$patch(success, fail);
+          return this.$patch({case_reference: case_reference}, success, fail);
         } else {
-          return this.$save(success, fail);
+          return this.$save({case_reference: case_reference}, success, fail);
         }
       };
 

--- a/cla_frontend/assets-src/javascripts/app/js/states.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states.js
@@ -49,16 +49,16 @@
         ).$promise;
       }],
       eligibility_check: ['case', 'EligibilityCheck', function(case_, EligibilityCheck){
-        return case_.eligibility_check ? EligibilityCheck.get({ref: case_.eligibility_check}).$promise : new EligibilityCheck();
+        return case_.eligibility_check ? EligibilityCheck.get({case_reference: case_.reference}).$promise : new EligibilityCheck({case_reference: case_.reference});
       }],
       personal_details: ['case', 'PersonalDetails', function(case_, PersonalDetails) {
-        return case_.personal_details ? PersonalDetails.get({ref: case_.personal_details}).$promise : new PersonalDetails();
+        return case_.personal_details ? PersonalDetails.get({case_reference: case_.reference}).$promise : new PersonalDetails({case_reference: case_.reference});
       }],
       adaptation_details: ['case', 'Adaptations', function(case_, Adaptations) {
-        return case_.adaptation_details ? Adaptations.get({ref: case_.adaptation_details}).$promise : new Adaptations();
+        return case_.adaptation_details ? Adaptations.get({case_reference: case_.reference}).$promise : new Adaptations({case_reference: case_.reference});
       }],
       thirdparty_details: ['case', 'ThirdParty', function(case_, ThirdParty) {
-        return case_.thirdparty_details ? ThirdParty.get({ref: case_.thirdparty_details}).$promise : new ThirdParty();
+        return case_.thirdparty_details ? ThirdParty.get({case_reference: case_.reference}).$promise : new ThirdParty({case_reference: case_.reference});
       }]
     },
     views: {


### PR DESCRIPTION
why? so we can log changes per case (not using nested resources would mean logging changes to an object e.g. personaldetails but there is no where to look at a log per object and all changes take place through the lens of a case.
this change means that you edit personaldetails through the case: /api/case/<case_ref>/personal_details/.

the benefit of this is that we also get rid of the associate_XXX_to_case calls from the frontend.
