### PR TITLE
Remove default of no timer

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/directives/timer.js
+++ b/cla_frontend/assets-src/javascripts/app/js/directives/timer.js
@@ -166,9 +166,6 @@
           $rootScope.timerRunning = false;
         };
 
-
-    $rootScope.timerRunning = false;
-
     // ACTION EVENTS
     // emitting timer:check and timer:start triggers this module
     // to call the backend and check if the timer is running or not


### PR DESCRIPTION
Stops the notification flashing up and then disappearing. 

@marcofucci Will this cause any problems? Still works as expected.
