### PR TITLE
Legal form printout css

### DIFF
--- a/cla_frontend/assets-src/stylesheets/views/_legal-help-form.scss
+++ b/cla_frontend/assets-src/stylesheets/views/_legal-help-form.scss
@@ -1,6 +1,14 @@
 #wrapper {
   width: 1024px;
   margin: 30px auto 0;
+  font-size: 13pt;
+}
+
+.header {
+  li {
+    max-width: 67%;
+    margin-bottom: 5px;
+  }
 }
 
 h1 {
@@ -51,6 +59,10 @@ ol {
   padding: 10px 15px;
   margin: 30px 0;
   @include box-shadow(8px 8px 0 $black);
+
+  &.notes {
+    font-size: 11pt;
+  }
 }
 
 .field-table {
@@ -87,7 +99,7 @@ input[type=text],
 textarea {
   @include core-16;
   font-weight: 700;
-  border: 1px solid $border-colour;
+  border: 1px solid $black;
   padding: 5px 0;
   text-indent: 5px;
   margin: 0;

--- a/cla_frontend/templates/cla_provider/legal_help_form.jade
+++ b/cla_frontend/templates/cla_provider/legal_help_form.jade
@@ -22,7 +22,7 @@ html(lang='en')
             ul
               li Check the details we have filled in from the telephone assessment are correct and change them if they are not
               li Attach any evidence requested and return the form to us
-              li Sign the declaration on page 4
+              li Sign the declaration on page 5
         fieldset.box
           table.field-table(width='100%')
             tbody
@@ -435,7 +435,7 @@ html(lang='en')
         p
           strong If you have a partner whose details have been completed on this form then they must sign the authority below.
         p
-          strong Partners Declaration.
+          strong Partner's Declaration.
         p This is a true statement of all my income and assets in the UK and abroad. I agree to the LAA checking these facts with others such as the Department of Work and Pensions (DWP) and the HM Revenue and Customs (HMRC) and I authorise those parties (including HMRC and DWP) to provide the information they are asked for.
         table.field-table(width='100%')
           tbody

--- a/cla_frontend/templates/cla_provider/legal_help_form.jade
+++ b/cla_frontend/templates/cla_provider/legal_help_form.jade
@@ -454,7 +454,7 @@ html(lang='en')
         p In order to fulfil its functions the MoJ may share personal data with other organisations. These organisations include other government departments, local authorities and private or voluntary sector organisations engaged to deliver services. Personal data is only shared outside the MoJ when the law allows.
         p To request a copy of your personal information please refer to the MoJ website for further details on how you may do this.
       // Notes
-      .page.box
+      .page.box.notes
         h2.section-heading Notes
         ol
           li By "partner" we mean anyone (including a person of the same sex) that you live with as a couple. Your partner "lives with" you even if they are not living in the same house as you (e.g. because you or your partner works away from home) unless one of you considers that your relationship is over. You should not give details of your partner's money if the problem you are seeking advice about is a dispute with your partner.


### PR DESCRIPTION
* bump up font size to help printed form legibility
* set box borders to black, again to aid clarity when form is printed
* typo: declaration is on page 5, not 4
* typo: "Partner's declaration", not "Partners declaration"