### PR TITLE
WIP: diversity and assign tab copy shuffle

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.diversity.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.diversity.js
@@ -18,13 +18,13 @@
       },
       resolve: {
         // check that the eligibility check can be accessed
-        CanAccess: ['$q', 'case', function ($q, $case) {
+        CanAccess: ['$q', 'case', 'diagnosis', 'eligibility_check', function ($q, $case, diagnosis, eligibility_check) {
           var deferred = $q.defer();
 
-          if (!$case.personal_details) {
+          if (!diagnosis.isInScopeTrue() || !eligibility_check.isEligibilityTrue()) {
             // reject promise and handle in $stateChangeError
             deferred.reject({
-              msg: 'You must add the client\'s details before completing the diversity questionnaire.',
+              msg: 'The Case must be <strong>in scope</strong> and <strong>eligible</strong> before completing the diversity questionnaire.',
               case: $case.reference,
               goto: 'case_detail.edit.diagnosis'
             });

--- a/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.assign.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.assign.html
@@ -39,9 +39,7 @@
   </div>
 
   <call-script ng-if="suggested_providers.length > 1 || suggested_provider">
-    <p>From the information you have provided, the assessment shows that you may be eligible for Legal Aid and I will transfer you to one of our Specialist Providers.</p>
-    <p>We cannot guarantee that the specialist will be able to take on your case, however their service is not your only option and the specialist will try to find you some help elsewhere. If they do take on your case you will need to provide proof of your financial circumstances for the specialist to continue.</p>
-    <p>I there anything else we can assist you with today?</p>
+    <p>Is there anything else we can assist you with today?</p>
     <p>If you require any further assistance please don't hesitate to call us back. We are open from 9am-8pm Monday to Friday and 9am-12:30pm on Saturdays.</p>
     <p>Thank you for calling Civil Legal Advice, I will now put you through to one of our Specialists.</p>
   </call-script>

--- a/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.diversity.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.diversity.html
@@ -8,6 +8,8 @@
 
 <div ng-if="!personal_details.has_diversity">
   <call-script>
+    <p>From the information you have provided, the assessment shows that you may be eligible for Legal Aid and I will transfer you to one of our Specialist Providers.</p>
+    <p>We cannot guarantee that the specialist will be able to take on your case, however their service is not your only option and the specialist will try to find you some help elsewhere. If they do take on your case you will need to provide proof of your financial circumstances for the specialist to continue.</p>
     <p>Before I transfer you, I just need to ask you some equality and diversity questions. You do not need to answer any of these questions but your cooperation in providing us with accurate data will ensure that we not only meet our legal obligations, but even more importantly will result in you receiving fair and just treatment in your interactions with us. Any information provided on this form will be treated as strictly confidential and will be used for statistical purposes only. No information will be published or used in any way which allows any individual to be identified.</p>
   </call-script>
 

--- a/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.edit.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.edit.html
@@ -1,6 +1,6 @@
 <div data-extend-template="case_detail.edit.html">
   <span data-block="extra-tabs">
-    <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.diversity'), 'is-disabled': !case.personal_details}">
+    <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.diversity'), 'is-disabled': !case.isInScopeAndEligible()}">
       <a ui-sref="case_detail.diversity" class="Tabs-tabLink" ng-class="{'Icon Icon--right Icon--solidTick Icon--green': personal_details.has_diversity}">Diversity</a>
     </li>
     <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.assign'), 'is-disabled': !case.isInScopeAndEligible()}">

--- a/tests/angular-js/e2e/diversityMonitoring.js
+++ b/tests/angular-js/e2e/diversityMonitoring.js
@@ -22,7 +22,7 @@
         modelsRecipe.Case.createEmpty().then(function (_caseRef) {
           browser.get(CONSTANTS.callcentreBaseUrl + _caseRef + '/');
           element(by.css('[ui-sref="case_detail.diversity"]')).click();
-          expect(notices.getText()).toContain('You must add the client\'s details before completing the diversity questionnaire.');
+          expect(notices.getText()).toContain('The Case must be in scope and eligible before completing the diversity questionnaire.');
         });
       });
 


### PR DESCRIPTION
- move eligibility script copy from assign tab to diversity tab
- make diversity tab only accessible when scope and eligibility completed
- correct typo

This relates to Pivotal story [84761466](https://www.pivotaltracker.com/story/show/84761466) but @tomdolanmoj is to confirm whether this is a definite requirement.
