### PR TITLE
Standardise app version variable

### DIFF
--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -23,7 +23,7 @@ PING_JSON_KEYS = {
 
     'build_date_key': 'APP_BUILD_DATE',
     'commit_id_key': 'APP_GIT_COMMIT',
-    'version_number_key': 'APPVERSION',
+    'version_number_key': 'APP_VERSION',
     'build_tag_key': 'APP_BUILD_TAG',
 
 }


### PR DESCRIPTION
This change sets the expected env variable containing the application
version as APP_VERSION rather than APPVERSION to bring it into line
with convention.