### PR TITLE
Remove action attribute from modal forms so that angular prevents default

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/partials/includes/login.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/includes/login.html
@@ -9,7 +9,7 @@
         <p>Your last session has timed out.
           <br>Sign in again to avoid losing any data you have entered.</p>
 
-        <form autocomplete="off" action="" method="post" ng-submit="login(login_frm)" name="login_frm">
+        <form autocomplete="off" method="post" ng-submit="login(login_frm)" name="login_frm">
           <span class="Error-message Error-all" ng-if="login_frm.$error.server">{{ errors.__all__ }}</span>
           <input type="hidden" name="csrfmiddlewaretoken" value="ouXbtrw2UtE9fg0dRwExncwVkP3MVgpP">
 

--- a/cla_frontend/assets-src/javascripts/app/partials/includes/reset_password.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/includes/reset_password.html
@@ -6,7 +6,7 @@
           <h1>Reset password for {{ user_.username }}</h1>
         </header>
 
-        <form action="" method="post" ng-submit="save(reset_frm)" name="reset_frm">
+        <form method="post" ng-submit="save(reset_frm)" name="reset_frm">
           <span class="Error-message Error-all" ng-show="reset_frm.$error.server">{{ errors.__all__ }}</span>
           <div class="FormRow cf" ng-show="!user.is_manager || user.username === user_.username">
             <label for="id_old_password" id="id_old_password-label">

--- a/cla_frontend/assets-src/javascripts/app/partials/includes/session_expiring.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/includes/session_expiring.html
@@ -2,7 +2,7 @@
   <h1>Your session is about to expire</h1>
 </header>
 
-<form autocomplete="off" action="" method="post" ng-submit="extend()" name="expire_frm">
+<form autocomplete="off" method="post" ng-submit="extend()" name="expire_frm">
   <p>You have been inactive for too long. Your session will expire in <strong idle-countdown="countdown">{{ countdown }}</strong> seconds if you do not do anything.</p>
 
   <div class="FormActions">


### PR DESCRIPTION
Having an ng-submit attribute gives a javascript action that is triggered
on form submission, but if the action attribute is present then the
default action is not prevented.