### PR TITLE
allow providers to split cases

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/partials/provider/case_detail.split.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/provider/case_detail.split.html
@@ -33,7 +33,7 @@
 
       <span class="Grid-col Grid-col--2-3">
         <span class="cf">
-          <select name="category" class="FormRow-field--full" placeholder="Choose category of law" ui-select2 ng-model="::$parent.category" ng-options="cat.code as cat.name for cat in categories track by cat.code" required server-error>
+          <select ui-select2 name="category" class="FormRow-field--full" placeholder="Choose category of law" ng-model="::$parent.$parent.category" ng-options="cat.code as cat.name for cat in categories track by cat.code" required server-error>
             <option value=""></option>
           </select>
         </span>
@@ -49,7 +49,7 @@
 
       <span class="Grid-col Grid-col--2-3">
         <span class="cf">
-          <select ui-select2 name="matter_type1" placeholder="Choose matter type 1" class="FormRow-field--inline FormRow-field--full" ng-model="::$parent.matterType1" ng-options="matterType.code as (matterType.code + ' - ' + matterType.description) for matterType in matterTypes | filter:{level: 1} track by matterType.code" ng-disabled="!matterTypes.length" ng-required="matterTypes.length" server-error>
+          <select ui-select2 name="matter_type1" placeholder="Choose matter type 1" class="FormRow-field--inline FormRow-field--full" ng-model="::$parent.$parent.matterType1" ng-options="matterType.code as (matterType.code + ' - ' + matterType.description) for matterType in matterTypes | filter:{level: 1} track by matterType.code" ng-disabled="!matterTypes.length" ng-required="matterTypes.length" server-error>
             <option value=""></option>
           </select>
         </span>
@@ -65,7 +65,7 @@
 
       <span class="Grid-col Grid-col--2-3">
         <span class="cf">
-          <select ui-select2 name="matter_type2" placeholder="Choose matter type 2" class="FormRow-field--inline FormRow-field--full" ng-model="::$parent.matterType2" ng-options="matterType.code as (matterType.code + ' - ' + matterType.description) for matterType in matterTypes | filter:{level: 2} track by matterType.code" ng-disabled="!matterTypes.length" ng-required="matterTypes.length" server-error>
+          <select ui-select2 name="matter_type2" placeholder="Choose matter type 2" class="FormRow-field--inline FormRow-field--full" ng-model="::$parent.$parent.matterType2" ng-options="matterType.code as (matterType.code + ' - ' + matterType.description) for matterType in matterTypes | filter:{level: 2} track by matterType.code" ng-disabled="!matterTypes.length" ng-required="matterTypes.length" server-error>
             <option value=""></option>
           </select>
         </span>
@@ -82,7 +82,7 @@
       <span class="Error-message" ng-if="split_case_frm.notes.$error.server">{{ errors.notes }}</span>
 
       <span class="Grid-col Grid-col--2-3">
-        <textarea name="notes" cols="30" rows="4" ng-model="::$parent.notes" placeholder="Enter comments"></textarea>
+        <textarea name="notes" cols="30" rows="4" ng-model="::$parent.$parent.notes" placeholder="Enter comments"></textarea>
       </span>
     </label>
 
@@ -96,7 +96,7 @@
       <span class="Grid-col Grid-col--2-3">
         <span class="FormRow">
           <label class="FormRow-label">
-            <input type="radio" name="internal" value="true" ng-model="::$parent.internal" required>
+            <input type="radio" name="internal" value="true" ng-model="::$parent.$parent.internal" required>
             <span class="FormRow-labelText">
               Internally to {{ ::user.provider.name }}
               <span class="Error-message" ng-if="errors.internal">{{ errors.internal }}</span>
@@ -105,7 +105,7 @@
         </span>
         <span class="FormRow">
           <label class="FormRow-label">
-            <input type="radio" name="internal" value="false" ng-model="::$parent.internal" required>
+            <input type="radio" name="internal" value="false" ng-model="::$parent.$parent.internal" required>
             <span class="FormRow-labelText">To operator for assignment</span>
           </label>
         </span>


### PR DESCRIPTION
This addresses a bug discovered as a result of the angularjs version
being updated from 1.3 to 1.4. Providers reported to us that when they
tried to split a case the two matter type lists where not being populated
and were disabled.

At first it seemed as though the category drop down list was not triggering
the change event which in turn would populate the two matter type drop
down lists. The issue related to the scope that was being used, the
scope in the view and the scope watch being used in the controller were
different and thats why it was not working.

As part of this commit, I discovered that no tests were setup for this
feature or for any other features since mid-2015. The existing tests do
no work and I think this needs to be addresses as a bigger issue and
ticket. Therefore I have not added any tests.