### PR TITLE
Only search for filter links

### DIFF
--- a/tests/angular-js/e2e/caseList.js
+++ b/tests/angular-js/e2e/caseList.js
@@ -24,13 +24,13 @@
       });
 
       it("should update URL for case filter selections", function() {
-        element(by.linkText("Phone cases")).click();
+        element(by.className('Filters')).element(by.linkText("Phone cases")).click();
         expect(browser.getCurrentUrl()).toContain("only=phone");
-        element(by.linkText("Web cases")).click();
+        element(by.className('Filters')).element(by.linkText("Web cases")).click();
         expect(browser.getCurrentUrl()).toContain("only=web");
-        element(by.linkText("EOD")).click();
+        element(by.className('Filters')).element(by.linkText("EOD")).click();
         expect(browser.getCurrentUrl()).toContain("only=eod");
-        element(by.linkText("My cases")).click();
+        element(by.className('Filters')).element(by.linkText("My cases")).click();
         expect(browser.getCurrentUrl()).toContain("only=my");
       });
     });


### PR DESCRIPTION
There are some instances when there are other links on the page that
similar text to the filters for eg. "EOD" this appears in the filters
and in the case list for Operator managers. The issue with not scoping
the search is that if the elements were moved around the test would
be searching and clicking on the wrong link and could return a false
positive.