### PR TITLE
Optimise dockerfile to leverage build cache

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "cla_frontend/assets-src/vendor",
-  "interactive": false
+  "interactive": false,
+  "allow_root": true
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ static/
 node_modules/
 cla_frontend/assets-src/vendor/
 venv/
+reports/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 # project
 Dockerfile
 docker-compose.yml
-cla_frontend/settings/local.py
+cla_frontend/settings/local.py*
 static/
 node_modules/
 cla_frontend/assets-src/vendor/

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ node_modules/
 cla_frontend/assets-src/vendor/
 venv/
 reports/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,29 +4,40 @@
 # Pull base image.
 FROM phusion/baseimage:0.9.22
 
-# Set correct environment variables.
+# Set environment variables.
 ENV HOME /root
+ENV DEBIAN_FRONTEND noninteractive
 
 # Use baseimage-docker's init process.
 CMD ["/sbin/my_init"]
 
+# Install updates and dependencies
+RUN apt-get update -qq && apt-get install -y --force-yes -qq \
+    bash apt-utils \
+    build-essential \
+    git \
+    libpq-dev \
+    libpcre3 \
+    libpcre3-dev \
+    nginx-full \
+    nodejs \
+    npm \
+    python-dev \
+    python-pip \
+    python-software-properties \
+    ruby-bundler \
+    software-properties-common \
+    tzdata \
+    && apt-get clean
+
 # Set timezone
-RUN echo $TZ > /etc/timezone && \
-    apt-get update && apt-get install -y tzdata && \
-    rm /etc/localtime && \
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata && \
-    apt-get clean
+RUN echo $TZ > /etc/timezone \
+    && rm /etc/localtime \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata 
 
 # Remove SSHD
 RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-
-# Dependencies
-RUN DEBIAN_FRONTEND='noninteractive' apt-get update && \
-  apt-get -y --force-yes install bash apt-utils python-pip \
-  python-dev build-essential git software-properties-common \
-  python-software-properties libpq-dev libpcre3 libpcre3-dev \
-  nodejs npm ruby-bundler nginx-full
 
 RUN npm install -g n   # Install n globally
 RUN n 8.9.3            # Install and use v8.9.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,10 +123,6 @@ COPY docker/                ./docker/
 COPY scripts/               ./scripts/
 COPY tests/                 ./tests/
 
-# Not sure why this is copied - .dockerignore has it listed - so delete manually
-# An error is thrown in the compile assets step if local.py is present
-RUN rm ./cla_frontend/settings/local.*
-
 # Compile assets
 RUN python manage.py builddata constants_json
 


### PR DESCRIPTION
I have re-ordered the Dockerfile. Here's why:

1. To learn about the project and how it's put together
2. To improve readability using more comments
3. To leverage Docker's build cache by grouping application dependencies together

Up to this point, the successful build times average around 7 to 8 minutes. [See the chart here](https://ci.service.dsd.io/view/CLA/job/BUILD-cla_frontend/buildTimeTrend).

<img width="498" alt="screen shot 2018-06-22 at 11 28 45" src="https://user-images.githubusercontent.com/89347/41772173-7b2697e8-760f-11e8-9378-c58c1202a5ed.png">

There's still more work to do. The resulting docker image size is 1.42GB. There's 500MB of node modules! Such a large file takes times to push to an environment.