### PR TITLE
LGA-394 Use cla_common postcode lookup

### DIFF
--- a/cla_frontend/apps/legalaid/postcode_lookup_views.py
+++ b/cla_frontend/apps/legalaid/postcode_lookup_views.py
@@ -1,56 +1,16 @@
-# -*- encoding: utf-8 -*-
-"""View for postcode lookups"""
-
+# coding=utf-8
+from cla_common.address_lookup.ordnance_survey import FormattedAddressLookup
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
-
-import postcodeinfo
 
 
 @login_required
 def postcode_lookup(request, path):
-    try:
-        return addresses_response(request)
-
-    except postcodeinfo.NoResults:
-        return no_results_response()
-
-    except postcodeinfo.PostcodeInfoException as e:
-        return error_response(e)
-
-
-def addresses_response(request):
-    return JsonResponse(
-        addresses_for_postcode_from_url_params(request),
-        safe=False
-    )
-
-
-def addresses_for_postcode_from_url_params(request):
-    return postcode_addresses(postcode_from_url_params(request))
-
-
-def postcode_from_url_params(request):
-    return request.GET.get('postcode')
-
-
-def postcode_addresses(postcode):
-    addresses = postcodeinfo.Client().lookup_postcode(postcode).addresses
-    return map(formatted_address_only, addresses)
-
-
-def formatted_address_only(address):
-    return dict(filter(formatted_address_item, address.iteritems()))
-
-
-def formatted_address_item(item):
-    key, val = item
-    return key == 'formatted_address'
-
-
-def no_results_response():
+    postcode = request.GET.get("postcode")
+    key = settings.OS_PLACES_API_KEY
+    formatted_addresses = FormattedAddressLookup(key=key).by_postcode(postcode)
+    if formatted_addresses:
+        response = [{"formatted_address": address} for address in formatted_addresses if address]
+        return JsonResponse(response, safe=False)
     return JsonResponse([], safe=False, status=404)
-
-
-def error_response(exc):
-    return JsonResponse({'error': str(exc)}, status=500)

--- a/cla_frontend/apps/legalaid/tests/test_postcode_lookup_views.py
+++ b/cla_frontend/apps/legalaid/tests/test_postcode_lookup_views.py
@@ -1,96 +1,30 @@
-# -*- encoding: utf-8 -*-
-"Tests for postcode_lookup view"
-
-import contextlib
+# coding=utf-8
 import json
-import unittest
 
 import mock
-import postcodeinfo
-
-from legalaid.postcode_lookup_views import no_results_response, \
-    postcode_from_url_params, postcode_addresses, \
-    addresses_for_postcode_from_url_params, postcode_lookup
+from core.testing.test_base import CLATFrontEndTestCase
+from django.test import RequestFactory
+from legalaid.postcode_lookup_views import postcode_lookup
 
 
-postcode = 'sw1a1aa'
-valid_addresses = [
-    {
-        "formatted_address": "Buckingham Palace\nLondon\nSW1A 1AA",
-    }
-]
-
-
-@contextlib.contextmanager
-def patch_postcodeinfo(postcode, result):
-    with mock.patch('postcodeinfo.Client') as Client:
-        client = Client.return_value
-        lookup = client.lookup_postcode
-
-        if callable(result):
-            lookup.side_effect = result
-        else:
-            lookup.return_value.addresses = result
-
-        yield
-
-        client.assertCalled()
-        lookup.assertCalledWith(postcode)
-
-
-class PostcodeLookupViewsTest(unittest.TestCase):
-
+class PostcodeLookupViewsTest(CLATFrontEndTestCase):
     def setUp(self):
-        self.request = mock.Mock()
-        self.request.GET.get.return_value = postcode
-        self.request.user.is_authenticated.return_value = True
+        self.request = RequestFactory().get("")
+        self.request.user = mock.MagicMock()
+        self.lookup_method_name = "cla_common.address_lookup.ordnance_survey.FormattedAddressLookup.by_postcode"
 
-    def assert_no_results(self, response):
-        self.assertEqual(404, response.status_code)
-        self.assertEqual('[]', response.content)
+    def test_response_packaging(self):
+        prerecorded_result = "Ministry of Justice\n52 Queen Annes Gate\nLondon\nSW1H 9AG"
+        expected_formatted_result = json.dumps([{"formatted_address": prerecorded_result}])
+        with mock.patch(self.lookup_method_name) as mock_method:
+            mock_method.return_value = [prerecorded_result]
+            response = postcode_lookup(self.request, "")
+            self.assertEqual(expected_formatted_result, response.content)
 
-    def assert_error(self, response):
-        self.assertEqual(500, response.status_code)
-
-    def assert_address_response(self, addresses, response):
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(json.dumps(addresses), response.content)
-
-    def test_no_results_response(self):
-        self.assert_no_results(no_results_response())
-
-    def test_postcode_from_url_params(self):
-        self.assertEqual(postcode, postcode_from_url_params(self.request))
-
-    def test_postcode_addresses(self):
-        with patch_postcodeinfo(postcode, valid_addresses):
-            addresses = postcode_addresses(postcode)
-            self.assertEqual(valid_addresses, addresses)
-
-    def test_addresses_for_postcode_from_url_params(self):
-        with patch_postcodeinfo(postcode, valid_addresses):
-            addresses = addresses_for_postcode_from_url_params(self.request)
-            self.assertEqual(valid_addresses, addresses)
-
-    def test_postcode_lookup(self):
-        with patch_postcodeinfo(postcode, valid_addresses):
-            response = postcode_lookup(self.request, '')
-            self.assert_address_response(valid_addresses, response)
-
-    def test_postcode_lookup_no_results(self):
-
-        def raise_exception(*args):
-            raise postcodeinfo.NoResults()
-
-        with patch_postcodeinfo(postcode, raise_exception):
-            response = postcode_lookup(self.request, '')
-            self.assert_no_results(response)
-
-    def test_server_error(self):
-
-        def raise_exception(*args):
-            raise postcodeinfo.ServiceUnavailable()
-
-        with patch_postcodeinfo(postcode, raise_exception):
-            response = postcode_lookup(self.request, '')
-            self.assert_error(response)
+    def test_no_results_status(self):
+        expected_formatted_result = json.dumps([])
+        with mock.patch(self.lookup_method_name) as mock_method:
+            mock_method.return_value = []
+            response = postcode_lookup(self.request, "")
+            self.assertEqual(expected_formatted_result, response.content)
+            self.assertEquals(404, response.status_code)

--- a/cla_frontend/settings/.example.local.py
+++ b/cla_frontend/settings/.example.local.py
@@ -34,10 +34,6 @@ LOGGING = {
     }
 }
 
-# requires a running instance of address-finder https://github.com/ministryofjustice/addressfinder
-ADDRESSFINDER_API_HOST = ''
-ADDRESSFINDER_API_TOKEN = ''
-
 ZENDESK_API_USERNAME = os.environ.get(
     'ZENDESK_API_USERNAME',
     '<Zendesk user email>')

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -285,9 +285,6 @@ SOCKETIO_SERVER_URL = os.environ.get('SOCKETIO_SERVER_URL',
     'http://localhost:8005/socket.io')
 SITE_HOSTNAME = os.environ.get('SITE_HOSTNAME', 'localhost')
 
-ADDRESSFINDER_API_HOST = os.environ.get('ADDRESSFINDER_API_HOST',
-    'http://127.0.0.1:8003')
-ADDRESSFINDER_API_TOKEN = os.environ.get('ADDRESSFINDER_API_TOKEN', '')
 
 # Zendesk feedback settings
 ZENDESK_API_USERNAME = os.environ.get('ZENDESK_API_USERNAME', '')

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -302,10 +302,8 @@ if 'RAVEN_CONFIG_DSN' in os.environ:
         #'raven.contrib.django.raven_compat.middleware.Sentry404CatchMiddleware',
     ) + MIDDLEWARE_CLASSES
 
-# EMAILS
 
-POSTCODEINFO_API_URL = os.environ.get('POSTCODEINFO_API_URL')
-POSTCODEINFO_AUTH_TOKEN = os.environ.get('POSTCODEINFO_AUTH_TOKEN')
+OS_PLACES_API_KEY = os.environ.get('OS_PLACES_API_KEY')
 
 # importing test settings file if necessary (TODO chould be done better)
 if len(sys.argv) > 1 and 'test' in sys.argv[1]:

--- a/cla_frontend/settings/testing.py
+++ b/cla_frontend/settings/testing.py
@@ -12,3 +12,5 @@ root = lambda *x: join(abspath(PROJECT_ROOT), *x)
 sys.path.insert(0, root('apps'))
 
 TEST_RUNNER = 'core.testing.runner.NoDbTestRunner'
+
+OS_PLACES_API_KEY = "DUMMY_KEY"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-widget-tweaks==1.3
 slumber==0.6.2
 python-dateutil==2.4.0
 
-git+git://github.com/ministryofjustice/cla_common.git@0.2.7#egg=cla_common==0.2.7
+git+git://github.com/ministryofjustice/cla_common.git@feature/os-places-address-lookup#egg=cla_common==0.3.0
 
 django-proxy==1.0.2
 django-csp==2.0.3
@@ -20,7 +20,7 @@ logstash-formatter==0.5.9
 django-ipware==0.1.0
 pyjade==3.0.0
 websocket-client==0.23.0
-requests==2.6.0
+requests==2.19.1
 django-extended-choices==0.3.0
 
 #Irat healthcheck and ping package

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,5 +25,3 @@ django-extended-choices==0.3.0
 
 #Irat healthcheck and ping package
 git+https://github.com/ministryofjustice/django-moj-irat.git@4d54b86b1cb574fe787ba0fb8a992cf352f8eba6
-
-postcodeinfo==0.2.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-widget-tweaks==1.3
 slumber==0.6.2
 python-dateutil==2.4.0
 
-git+git://github.com/ministryofjustice/cla_common.git@feature/os-places-address-lookup#egg=cla_common==0.3.0
+git+git://github.com/ministryofjustice/cla_common.git@0.3.0#egg=cla_common==0.3.0
 
 django-proxy==1.0.2
 django-csp==2.0.3


### PR DESCRIPTION
## What does this pull request do?

`postcodeinfo` is deprecated and EOL 2018-12-31. This replaces `postcodeinfo` with Ordnance Survey's Places API address lookup implemented in `cla_common`

Responses from view maintain compatiblity with frontend.

## Any other changes that would benefit highlighting?

`cla_common` requirement temporarily switched to feature branch until PR is merged and tag exists so we can use `cla_common==0.3.0`

`requests` requirement version bumped to fix SSL issue

No longer propagates errors to frontend. Logs the error (to Sentry) and returns 404.