### PR TITLE
Stubbed PingJsonView to fix deploys

### DIFF
--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -11,14 +11,6 @@ function tag_and_push() {
   docker push $tag
 }
 
-function tag_and_push_twice() {
-  tag="$1"
-  echo
-  echo "Tagging and pushing $tag..."
-  docker tag $built_tag $tag
-  docker push $tag || docker push $tag
-}
-
 if [ "$CIRCLE_BRANCH" == "master" ]; then
   tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
   tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
@@ -26,4 +18,4 @@ if [ "$CIRCLE_BRANCH" == "master" ]; then
 fi
 tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
 tag_and_push "$ECR_DEPLOY_IMAGE"
-tag_and_push_twice "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"
+tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -8,7 +8,10 @@ function tag_and_push() {
   echo
   echo "Tagging and pushing $tag..."
   docker tag $built_tag $tag
-  docker push $tag || docker push $tag
+  docker push $tag
+  while [ $? -ne 0 ]; do
+    docker push $tag
+  done
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -8,7 +8,7 @@ function tag_and_push() {
   echo
   echo "Tagging and pushing $tag..."
   docker tag $built_tag $tag
-  docker push $tag
+  docker push $tag || docker push $tag
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -11,6 +11,14 @@ function tag_and_push() {
   docker push $tag
 }
 
+function tag_and_push_twice() {
+  tag="$1"
+  echo
+  echo "Tagging and pushing $tag..."
+  docker tag $built_tag $tag
+  docker push $tag || docker push $tag
+}
+
 if [ "$CIRCLE_BRANCH" == "master" ]; then
   tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
   tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
@@ -18,4 +26,4 @@ if [ "$CIRCLE_BRANCH" == "master" ]; then
 fi
 tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
 tag_and_push "$ECR_DEPLOY_IMAGE"
-tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"
+tag_and_push_twice "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -8,10 +8,9 @@ function tag_and_push() {
   echo
   echo "Tagging and pushing $tag..."
   docker tag $built_tag $tag
-  docker push $tag
-  while [ $? -ne 0 ]; do
-    docker push $tag
-  done
+  # Multiple push attempts to work around DSD registry 504 timeouts:
+  # https://github.com/ministryofjustice/cloud-platform/issues/572
+  docker push $tag || docker push $tag || docker push $tag
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then

--- a/cla_frontend/apps/status/urls.py
+++ b/cla_frontend/apps/status/urls.py
@@ -1,8 +1,5 @@
 from django.conf.urls import patterns, url
-from django.conf import settings
-
-from moj_irat.views import PingJsonView, HealthcheckView
-
+from moj_irat.views import HealthcheckView
 from . import views
 
 
@@ -10,6 +7,6 @@ urlpatterns = patterns(
     '',
     url(r'^$', views.status, name='status'),
     url(r'^status.json$', views.smoketests_json),
-    url(r'^ping.json$', PingJsonView.as_view(**settings.PING_JSON_KEYS), name='ping_json'),
+    url(r'^ping.json$', views.PingJsonView.as_view(), name='ping_json'),
     url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
 )

--- a/cla_frontend/apps/status/views.py
+++ b/cla_frontend/apps/status/views.py
@@ -1,19 +1,11 @@
 import datetime
-import json
 
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.shortcuts import render
-
+from django.views.generic import View
 from cla_common.smoketest import smoketest
-from .smoketests import basic, smoketests
 
-
-class JSONResponse(HttpResponse):
-
-    def __init__(self, data, **kwargs):
-        content = json.dumps(data)
-        kwargs['content_type'] = 'application/json'
-        super(JSONResponse, self).__init__(content, **kwargs)
+from .smoketests import smoketests
 
 
 def status(request):
@@ -31,8 +23,7 @@ def smoketests_json(request):
     """
     Run smoke tests and return results as JSON datastructure
     """
-
     from cla_frontend.apps.status.tests.smoketests import SmokeTests
+    return JsonResponse(smoketest(SmokeTests))
 
-    return JSONResponse(smoketest(SmokeTests))
 

--- a/cla_frontend/apps/status/views.py
+++ b/cla_frontend/apps/status/views.py
@@ -29,7 +29,7 @@ def smoketests_json(request):
 
 class PingJsonView(View):
     """
-    Stub IRaT PingJsonView for compatibility with current and imminent infra changes
+    Stub IRaT PingJsonView for compatibility with current and imminent move to Kubernetes, obviating this view
     """
     def get(self, request):
         response_data = {"build_tag": None,

--- a/cla_frontend/apps/status/views.py
+++ b/cla_frontend/apps/status/views.py
@@ -27,3 +27,13 @@ def smoketests_json(request):
     return JsonResponse(smoketest(SmokeTests))
 
 
+class PingJsonView(View):
+    """
+    Stub IRaT PingJsonView for compatibility with current and imminent infra changes
+    """
+    def get(self, request):
+        response_data = {"build_tag": None,
+                         "build_date": None,
+                         "version_number": None,
+                         "commit_id": None}
+        return JsonResponse(response_data)

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -19,15 +19,6 @@ HEALTHCHECKS = [
 
 AUTODISCOVER_HEALTHCHECKS = True
 
-PING_JSON_KEYS = {
-
-    'build_date_key': 'APP_BUILD_DATE',
-    'commit_id_key': 'APP_GIT_COMMIT',
-    'version_number_key': 'APP_VERSION',
-    'build_tag_key': 'APP_BUILD_TAG',
-
-}
-
 # ENVIRON values
 
 from django.core.exceptions import ImproperlyConfigured


### PR DESCRIPTION
## What does this pull request do?

Replace ping response with a stub for compatibility with current deploys, as discussed, and future infra work.

Replace custom JsonResponse with native Django.

As a temporary workaround recommended by Cloud Platform, try [multiple docker pushes](https://github.com/ministryofjustice/cla_frontend/pull/629/commits/5e46123527372b0597c32e7b537e25a18a4fadfd) to workaround DSD registry timeouts.

## Any other changes that would benefit highlighting?
This duplicates [PR 628](https://github.com/ministryofjustice/cla_frontend/pull/628), but shortens the branch name so DSD docker registry accepts the image.

Amended docstring to cover clarifying comment on PR 628.