### PR TITLE
LGA-418 Pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,4 @@ repos:
     rev: v2.1.0
     hooks:
     - id: flake8
+      args: ['--config=setup.cfg',  '--exclude=./cla_frontend/settings/*']


### PR DESCRIPTION
## What does this pull request do?

Ignore settings for flake8 until they're inverted in LGA-419, currently wallowing in the backlog and unlikely to make it into the next sprint.

## Any other changes that would benefit highlighting?

None
