### PR TITLE
LGA-477: Use pip version 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,8 @@ jobs:
           command: |
             pip install virtualenv
             virtualenv env
+            source env/bin/activate
+            pip install pip==18.1
       - restore_cache:
           keys:
             - pip-v1-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN chown -R www-data:www-data /var/lib/nginx && \
     chown www-data:www-data /etc/nginx/conf.d/htpassword
 
 # Pip install Python packages
-RUN pip install -U setuptools pip wheel
+RUN pip install -U setuptools pip==18.1 wheel
 RUN pip install GitPython uwsgi
 
 RUN mkdir -p /var/log/wsgi /var/log/nodejs && \


### PR DESCRIPTION
## What does this pull request do?

In CircleCI, the test jobs are currently failing

https://www.python.org/dev/peps/pep-0517/ causes problems with cla_common and pip 19 uses it by default.

Using --no-use-pep517 does not work with pip install -r requirements.txt. The workaround is to downgrade to the previous version of pip.

## Any other changes that would benefit highlighting?

We can upgrade to the next pip version if cla_common is made compatible with https://www.python.org/dev/peps/pep-0517/.

Same as ministryofjustice/cla_public#800
