### PR TITLE
Add documentation for release to training environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,17 @@ to stop the docker-compose up and then run it again.
     * `environment` is the target environment, select depending on your needs, eg. "demo", "staging", etc.
     * `branch` is the [deploy repo's](https://github.com/ministryofjustice/cla_frontend-deploy) default branch name, usually master.
 
+### Releasing to training
+
+1. Please make sure you tested on a non-production environment before merging.
+1. Merge your feature branch pull request to `master`.
+1. Wait for [the Docker build to complete on CircleCI](https://circleci.com/gh/ministryofjustice/cla_frontend/tree/master) for the `master` branch.
+1. Copy the `master.<sha>` reference from the `build` job's "Push Docker image" step. Eg:
+    ```
+    Pushing tag for rev [d96e0157bdac] on {https://registry.service.dsd.io/v1/repositories/cla_frontend/tags/master.b24490d}
+    ```
+1. [Deploy `master.<sha>` to **training**](https://ci.service.dsd.io/job/DEPLOY-cla_frontend/build?delay=0sec).
+
 ### Releasing to production
 
 >#### :warning: Release to production outside of business hours


### PR DESCRIPTION
## What does this pull request do?

Providers use the training environment to test export and new features. Training should be as up to date as production and should be included in the deployment process.

## Any other changes that would benefit highlighting?

Intentionally left blank.
