### PR TITLE
LGA-438 Add pip check to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,10 +96,6 @@ jobs:
           command: |
             source env/bin/activate
             pip install --requirement requirements/testing.txt
-      - run:
-          name: Check dependencies compatibility
-          command: |
-            source env/bin/activate
             pip check
       - save_cache:
           key: pip-v1-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,11 @@ jobs:
           command: |
             source env/bin/activate
             pip install --requirement requirements/testing.txt
+      - run:
+          name: Check dependencies compatibility
+          command: |
+            source env/bin/activate
+            pip check
       - save_cache:
           key: pip-v1-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}
           paths:


### PR DESCRIPTION
## What does this pull request do?

Add `pip check` to CI test job to verify dependency compatibility.

## Any other changes that would benefit highlighting?

This will remain un-mergeable until Django 1.8 upgrade resolves django-moj-irat 0.3 incompatibility.

## Checklist

- [X] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
