### PR TITLE
LGA-605 - Saved contact preference not displaying in CHS

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/partials/includes/personal_details.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/includes/personal_details.html
@@ -59,7 +59,7 @@
 
     <p class="VCard-row" ng-if="case.exempt_user">User is exempt because: {{ getExemptReasonByCode(case.exempt_user_reason).text }}</p>
 
-    <p class="VCard-row" ng-if="personal_details.full_name">User <strong ng-if="personal_details.contact_for_research">can</strong><strong ng-if="!personal_details.contact_for_research">cannot</strong> be contacted for research</p>
+    <p class="VCard-row" ng-if="personal_details.full_name">User <strong ng-if="personal_details.contact_for_research">can</strong><strong ng-if="!personal_details.contact_for_research">cannot</strong> be contacted for research<span ng-if="personal_details.contact_for_research && personal_details.contact_for_research_via"> via {{ getDisplayLabel(personal_details.contact_for_research_via, contact_for_research_via_choices) | lowercase }}</span></p>
 
     <p class="VCard-row" ng-if="adaptations.notes">
       {{ adaptations.notes }}


### PR DESCRIPTION
## What does this pull request do?

Displays the value of `contact_for_research_via` in the personal details area of the call handling system (alongside the value of the `contact_for_research` boolean field)
![image](https://user-images.githubusercontent.com/1237986/55736243-da527f80-5a1a-11e9-9e94-3a63cd2147c2.png)

## Any other changes that would benefit highlighting?

The issue was reported as the field not saving, but this was in fact the issue causing people to think that

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
