### PR TITLE
LGA-851 - Make Diversity tab require eligible, in-scope case

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.diversity.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.diversity.js
@@ -18,13 +18,20 @@
       },
       resolve: {
         // check that the eligibility check can be accessed
-        CanAccess: ['$q', 'case', function ($q, $case) {
+        CanAccess: ['$q', 'diagnosis', 'eligibility_check', 'case', function ($q, diagnosis, eligibility_check, $case) {
           var deferred = $q.defer();
 
           if (!$case.personal_details) {
             // reject promise and handle in $stateChangeError
             deferred.reject({
               msg: 'You must add the client\'s details before completing the diversity questionnaire.',
+              case: $case.reference,
+              goto: 'case_detail.edit.diagnosis'
+            });
+          } else if (!diagnosis.isInScopeTrue() || !eligibility_check.isEligibilityTrue()) {
+            // reject promise and handle in $stateChangeError
+            deferred.reject({
+              msg: 'The Case must be <strong>in scope</strong> and <strong>eligible</strong> in order to complete the diversity questionnaire.',
               case: $case.reference,
               goto: 'case_detail.edit.diagnosis'
             });

--- a/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.edit.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.edit.html
@@ -1,6 +1,6 @@
 <div data-extend-template="case_detail.edit.html">
   <span data-block="extra-tabs">
-    <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.diversity'), 'is-disabled': !case.personal_details}">
+    <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.diversity'), 'is-disabled': !case.isInScopeAndEligible()}">
       <a ui-sref="case_detail.diversity" class="Tabs-tabLink" ng-class="{'Icon Icon--right Icon--solidTick Icon--green': personal_details.has_diversity}">Diversity</a>
     </li>
     <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.assign'), 'is-disabled': !case.isInScopeAndEligible()}">


### PR DESCRIPTION
## What does this pull request do?

Grey-out the Diversity tab, and redirect the `resolve` step if the check
is failed (like we already do on the Assign tab)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
