### PR TITLE
LGA-915 - Add outcome description as abbr title on case page

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/partials/case_detail.outcome.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/case_detail.outcome.html
@@ -7,7 +7,7 @@
 
     <ul class="CaseHistory-log">
       <li class="CaseHistory-logItem cf" ng-repeat="log in logList">
-        <span class="CaseHistory-label" ng-if="log.type == 'outcome'">{{ ::log.code }}</span>
+        <abbr class="CaseHistory-label" ng-if="log.type == 'outcome'" title="{{ log.description }}">{{ ::log.code }}</abbr>
 
         <details ng-if="log.code === 'MT_CHANGED' || log.code === 'MT_CREATED'">
           <summary role="button">Means test {{ ::log.code === 'MT_CREATED' ? 'created' : 'changed' }}</summary>


### PR DESCRIPTION
## What does this pull request do?
Shows the full outcome name (eg "Callback 1") when hovering over the outcome code pill on the case details page. This is functionality the list page already has.

## Any other changes that would benefit highlighting?
~~Requires https://github.com/ministryofjustice/cla_backend/pull/611 to function, but will not break catastrophically without it (the code will be marked up as an `abbr`, so a title will be expected, but the title will be empty)~~ The backend code it depends on has now been deployed

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
