### PR TITLE
LGA-890 - Allow callback operators to view callback calendar

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_list.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_list.html
@@ -16,7 +16,7 @@
     </span>
   </span>
 
-  <nav data-block="page-nav" class="u-pullRight" ng-if="user.is_manager">
+  <nav data-block="page-nav" class="u-pullRight">
     <a ui-sref="case_list" class="BtnGroup-button BtnGroup-button--light" ng-class="{'is-selected': $state.is('case_list')}"><span class="Icon Icon--compact Icon--list"></span></a>
     <a ui-sref="case_list.callbacks" class="BtnGroup-button BtnGroup-button--light" ng-class="{'is-selected': $state.is('case_list.callbacks')}"><span class="Icon Icon--compact Icon--date"></span></a>
   </nav>

--- a/cla_frontend/assets-src/javascripts/app/partials/directives/callbackModal.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/directives/callbackModal.html
@@ -8,6 +8,7 @@
       <nav class="CallbackModal-daySelect">
         <button name="set-today" class="Button Button--secondary" type="button" ng-click="setToday($event)">Today</button>
         <button name="set-tomorrow" class="Button Button--secondary" type="button" ng-click="setTomorrow($event)">Tomorrow</button>
+        <a class="Button Button--secondary" ui-sref="case_list.callbacks" target="_blank" class="BtnGroup-button BtnGroup-button--light"><span class="Icon Icon--compact Icon--date"></span></a>
       </nav>
 
       <span class="Error-message" ng-if="errors.datetime">{{ errors.datetime }}</span>


### PR DESCRIPTION
## What does this pull request do?

Allow callback operators to view callback calendar so that they can pick a less busy time when scheduling callbacks

## Any other changes that would benefit highlighting?

Previously there were no permissions around the callback calendar stopping operators accessing it. Instead the link to the callback calendar was not shown for non manager users. This PR displays the link to all call centre users (providers are not call centre users).

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
