### PR TITLE
LGA-1124 Anonymise all search data being sent to CHS Google Analytics

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "angular-socket-io": "0.6.0",
     "socket.io-client": "1.7.4",
     "rome": "1.2.1",
-    "angulartics": "0.16.5",
+    "angulartics": "1.6.0",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#1.4.5",
     "angular-local-storage": "0.1.3",
     "papaparse": "3.1.4",
@@ -33,7 +33,8 @@
     "raven-js": "1.1.16",
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "moment-timezone": "~0.3.1",
-    "angular-sticky": "angular-sticky-plugin#^0.4.2"
+    "angular-sticky": "angular-sticky-plugin#^0.4.2",
+    "angulartics-google-analytics": "0.5.0"
   },
   "resolutions": {
     "angular": "1.4.13",

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -81,11 +81,12 @@
       });
     }];
 
-  common_config = ['$resourceProvider', 'cfpLoadingBarProvider',
-    function($resourceProvider, cfpLoadingBarProvider) {
+  common_config = ['$resourceProvider', 'cfpLoadingBarProvider', '$analyticsProvider',
+    function($resourceProvider, cfpLoadingBarProvider, $analyticsProvider) {
     $resourceProvider.defaults.stripTrailingSlashes = false;
     cfpLoadingBarProvider.includeBar = false;
-  }];
+    $analyticsProvider.queryKeysBlacklist(['search']);
+    }];
 
 
   //

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/search.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/search.js
@@ -14,7 +14,8 @@
 
           $scope.submit = function() {
             var action = ($state.current.name.indexOf('complaint') !== -1)? 'complaints_list' : 'case_list';
-            $state.go(action, {search: $scope.search}, {inherit: false});
+            $state.go(action, {search: $scope.search}, {inherit: false, location: false});
+
           };
         }
       ]

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/search.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/search.js
@@ -14,7 +14,7 @@
 
           $scope.submit = function() {
             var action = ($state.current.name.indexOf('complaint') !== -1)? 'complaints_list' : 'case_list';
-            $state.go(action, {search: $scope.search}, {inherit: false, location: false});
+            $state.go(action, {search: $scope.search}, {inherit: false});
 
           };
         }

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/search.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/search.js
@@ -15,7 +15,6 @@
           $scope.submit = function() {
             var action = ($state.current.name.indexOf('complaint') !== -1)? 'complaints_list' : 'case_list';
             $state.go(action, {search: $scope.search}, {inherit: false});
-
           };
         }
       ]

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -63,7 +63,7 @@
       paths.src + 'vendor/socket.io-client/dist/socket.io.js',
       paths.src + 'vendor/angular-socket-io/socket.js',
       paths.src + 'vendor/angulartics/src/angulartics.js',
-      paths.src + 'vendor/angulartics/src/angulartics-ga.js',
+      paths.src + 'vendor/angulartics-google-analytics/lib/angulartics-ga.js',
       paths.src + 'vendor/angular-hotkeys/build/hotkeys.js',
       paths.src + 'vendor/ng-text-truncate/ng-text-truncate.js',
       paths.src + 'vendor/angular-local-storage/dist/angular-local-storage.js',


### PR DESCRIPTION
## What does this pull request do?

One of the features of the CHS system is in searching for details for a specific client. When searching for client details, CHS users can use search terms such as (a client's) name, postcode in order to find the intended person. After searching for a client, the search terms used are shown in the browser, exposing the client's personal details 

Before: After searching for a client on the CHS system using key terms like their name or address, the information used in searching for the client (e.g. name, postcode etc) will appear in the URL and be exposed.

Now: After searching for a client, if the page contains a query string key containing search, that page will not get sent to GA.

## Any other changes that would benefit highlighting?

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
