### PR TITLE
LGA-1053 - Require updated cla_common library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN chown -R www-data:www-data /var/lib/nginx && \
     chown www-data:www-data /etc/nginx/conf.d/htpassword
 
 # Pip install Python packages
-RUN pip install -U setuptools pip==18.1 wheel
+RUN pip install -U pip
+RUN pip install -U setuptools wheel
 RUN pip install GitPython uwsgi
 
 RUN mkdir -p /var/log/wsgi /var/log/nodejs && \

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-widget-tweaks==1.3
 slumber==0.6.2
 python-dateutil==2.4.0
 
-git+git://github.com/ministryofjustice/cla_common.git@0.3.7#egg=cla_common
+git+git://github.com/ministryofjustice/cla_common.git@0.3.8#egg=cla_common
 
 django-proxy==1.0.2
 django-csp==2.0.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-widget-tweaks==1.3
 slumber==0.6.2
 python-dateutil==2.4.0
 
-git+git://github.com/ministryofjustice/cla_common.git@b7b64cc132a602796e71b8b0cebbe8d4137d4795#egg=cla_common==b7b64cc132a602796e71b8b0cebbe8d4137d4795
+git+git://github.com/ministryofjustice/cla_common.git@0.3.7#egg=cla_common
 
 django-proxy==1.0.2
 django-csp==2.0.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-widget-tweaks==1.3
 slumber==0.6.2
 python-dateutil==2.4.0
 
-git+git://github.com/ministryofjustice/cla_common.git@0.3.8#egg=cla_common
+git+git://github.com/ministryofjustice/cla_common.git@0.3.9#egg=cla_common
 
 django-proxy==1.0.2
 django-csp==2.0.3


### PR DESCRIPTION
## What does this pull request do?

This version of cla_common updates the operator hours constant


## Any other changes that would benefit highlighting?

Also fixes a build fail that emerged recently, by upgrading pip on its own before using it to upgrade anything else


## Checklist

- [X] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
