### PR TITLE
LGA-1211 Ensure refreshing CHS search pages does not send data to GA

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -60,6 +60,13 @@
       });
       $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
         // log the previous state in the History
+        ga(function(tracker) {
+          var location = tracker.get('location');
+          if(location.includes('search')) {
+            var newURL = location.replace(/search=[^&]+/gi, 'search=redacted');
+            ga('set', 'location', newURL);
+          }
+        });
         History.previousState = fromState;
         History.previousState.params = fromParams;
       });

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -61,10 +61,9 @@
       $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
         // log the previous state in the History
         ga(function(tracker) {
-          const location = tracker.get('location');
+          var location = tracker.get('location');
           if(location.includes('search')) {
-            const urlSegments = location.split('?search');
-            const newURL = urlSegments[0];
+            var newURL = location.replace(/search=[^&]+/gi, 'search=redacted');
             ga('set', 'location', newURL);
           }
         });

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -60,6 +60,14 @@
       });
       $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
         // log the previous state in the History
+        ga(function(tracker) {
+          const location = tracker.get('location');
+          if(location.includes('search')) {
+            const urlSegments = location.split('?search');
+            const newURL = urlSegments[0];
+            ga('set', 'location', newURL);
+          }
+        });
         History.previousState = fromState;
         History.previousState.params = fromParams;
       });
@@ -83,10 +91,10 @@
 
   common_config = ['$resourceProvider', 'cfpLoadingBarProvider', '$analyticsProvider',
     function($resourceProvider, cfpLoadingBarProvider, $analyticsProvider) {
-    $resourceProvider.defaults.stripTrailingSlashes = false;
-    cfpLoadingBarProvider.includeBar = false;
-    $analyticsProvider.queryKeysBlacklist(['search']);
-    }];
+      $resourceProvider.defaults.stripTrailingSlashes = false;
+      cfpLoadingBarProvider.includeBar = false;
+      $analyticsProvider.queryKeysBlacklist(['search']);
+  }];
 
 
   //

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -60,13 +60,6 @@
       });
       $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
         // log the previous state in the History
-        ga(function(tracker) {
-          var location = tracker.get('location');
-          if(location.includes('search')) {
-            var newURL = location.replace(/search=[^&]+/gi, 'search=redacted');
-            ga('set', 'location', newURL);
-          }
-        });
         History.previousState = fromState;
         History.previousState.params = fromParams;
       });


### PR DESCRIPTION
## What does this pull request do?

- Removes user data that gets sent to Google Analytics upon refreshing the page
- Only takes place when eg. a CHS member searches for a user, then refreshes the page. 
- This is because when a CHS member searches for a user, the 'search' word appears in the URL

## Any other changes that would benefit highlighting?

I've changed whatever the search term query is to 'redacted' as done here in a previous piece of work https://github.com/ministryofjustice/cla_public/commit/d965f7dd9447219b895296cf03c2bdfea2e46808. 

E.g. if a CHS members searches for a person called 'Bob', it would show as `localhost:8001/call_centre/search=redacted`

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
