### PR TITLE
 LGA-1348 - Adding maintenance page

### DIFF
--- a/cla_frontend/apps/core/middleware.py
+++ b/cla_frontend/apps/core/middleware.py
@@ -1,5 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
+from django.conf import settings
+from django.shortcuts import redirect
 
 
 class HttpResponseForbidden(HttpResponse):
@@ -11,3 +13,14 @@ class Cla401Middleware(object):
         if isinstance(exception, PermissionDenied):
             return HttpResponseForbidden()
         return None
+
+
+class MaintenanceModeMiddleWare(object):
+    MAINTENANCE_PATH = "/maintenance"
+
+    def process_request(self, request):
+        maintenance_mode = getattr(settings, "MAINTENANCE_MODE", False)
+        if maintenance_mode and request.path != self.MAINTENANCE_PATH:
+            return redirect(self.MAINTENANCE_PATH)
+        if not maintenance_mode and request.path == self.MAINTENANCE_PATH:
+            return redirect("/")

--- a/cla_frontend/apps/core/middleware.py
+++ b/cla_frontend/apps/core/middleware.py
@@ -17,10 +17,11 @@ class Cla401Middleware(object):
 
 class MaintenanceModeMiddleWare(object):
     MAINTENANCE_PATH = "/maintenance"
+    EXEMPT_PATHS = ["/status/ping.json", MAINTENANCE_PATH]
 
     def process_request(self, request):
         maintenance_mode = getattr(settings, "MAINTENANCE_MODE", False)
-        if maintenance_mode and request.path != self.MAINTENANCE_PATH:
+        if maintenance_mode and request.path not in self.EXEMPT_PATHS:
             return redirect(self.MAINTENANCE_PATH)
         if not maintenance_mode and request.path == self.MAINTENANCE_PATH:
             return redirect("/")

--- a/cla_frontend/apps/core/middleware.py
+++ b/cla_frontend/apps/core/middleware.py
@@ -15,7 +15,7 @@ class Cla401Middleware(object):
         return None
 
 
-class MaintenanceModeMiddleWare(object):
+class MaintenanceModeMiddleware(object):
     MAINTENANCE_PATH = "/maintenance"
     EXEMPT_PATHS = ["/status/ping.json", MAINTENANCE_PATH]
 

--- a/cla_frontend/apps/core/testing/test_views.py
+++ b/cla_frontend/apps/core/testing/test_views.py
@@ -1,0 +1,29 @@
+from django.test import SimpleTestCase
+
+
+class MaintenanceModeTestCase(SimpleTestCase):
+    def test_maintenance_mode_enabled_home_page(self):
+        with self.settings(MAINTENANCE_MODE=True):
+            response = self.client.get("/", follow=True)
+            self.assertEqual(503, response.status_code)
+            self.assertIn("This service is down for maintenance", response.content)
+            self.assertEqual([("http://testserver/maintenance", 302)], response.redirect_chain)
+
+    def test_maintenance_mode_enabled_maintenance_page(self):
+        with self.settings(MAINTENANCE_MODE=True):
+            response = self.client.get("/maintenance", follow=False)
+            self.assertEqual(503, response.status_code)
+            self.assertIn("This service is down for maintenance", response.content)
+
+    def test_maintenance_mode_disabled_home_page(self):
+        with self.settings(MAINTENANCE_MODE=False):
+            response = self.client.get("/", follow=True)
+            self.assertEqual(200, response.status_code)
+            self.assertNotIn("This service is down for maintenance", response.content)
+
+    def test_maintenance_mode_disabled_maintenance_page(self):
+        with self.settings(MAINTENANCE_MODE=False):
+            response = self.client.get("/maintenance", follow=True)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(("http://testserver/", 302), response.redirect_chain[0])
+            self.assertNotIn("This service is down for maintenance", response.content)

--- a/cla_frontend/apps/core/urls.py
+++ b/cla_frontend/apps/core/urls.py
@@ -1,0 +1,4 @@
+from django.conf.urls import patterns, url
+from .views import MaintenanceModeView
+
+urlpatterns = patterns("", url(r"^maintenance$", view=MaintenanceModeView.as_view(), name="maintenance_page"))

--- a/cla_frontend/apps/core/views.py
+++ b/cla_frontend/apps/core/views.py
@@ -1,0 +1,9 @@
+from django.views.generic import TemplateView
+
+
+class MaintenanceModeView(TemplateView):
+    template_name = "maintenance.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)
+        return self.render_to_response(context, status=503)

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -118,6 +118,7 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    "core.middleware.MaintenanceModeMiddleWare",
     "django_statsd.middleware.GraphiteRequestTimingMiddleware",
     "django_statsd.middleware.GraphiteMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -118,7 +118,7 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    "core.middleware.MaintenanceModeMiddleWare",
+    "core.middleware.MaintenanceModeMiddleware",
     "django_statsd.middleware.GraphiteRequestTimingMiddleware",
     "django_statsd.middleware.GraphiteMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/cla_frontend/templates/base.html
+++ b/cla_frontend/templates/base.html
@@ -62,6 +62,7 @@
         {% endif %}
 
         {% if zone %}
+        {% block buttons %}
           <button type="button" class="feedbackButton Icon Icon--feedback" ng-click="toggle()" title="Send feedback">
             <span class="visuallyhidden">Send feedback</span>
           </button>
@@ -79,6 +80,7 @@
               </ul>
             </nav>
           </div>
+        {% endblock %}
 
           {% block timer %}{% endblock %}
         {% endif %}
@@ -130,6 +132,7 @@
       {% endblock %}
     </main>
 
+    {% block base_javascript %}
     <script src="{% static 'javascripts/lib.min.js' %}"></script>
     <script src="{% static 'javascripts/vendor/vanilla-js.js' %}"></script>
     <script src="{% staticmin 'javascripts/cla.main.js' %}"></script>
@@ -137,6 +140,7 @@
     {% if debug %}
     <script src="{% static 'javascripts/vendor/postal.diagnostics.js' %}"></script>
     {% endif %}
+    {% endblock %}
     {% block javascripts %}{% endblock %}
 
     {% block body_end %}{% endblock %}

--- a/cla_frontend/templates/maintenance.html
+++ b/cla_frontend/templates/maintenance.html
@@ -1,4 +1,4 @@
-{% extends "503.html" %}
+{% extends "base.html" %}
 
 {% block search %}{% endblock %}
 {% block buttons %}{% endblock %}

--- a/cla_frontend/templates/maintenance.html
+++ b/cla_frontend/templates/maintenance.html
@@ -1,0 +1,10 @@
+{% extends "503.html" %}
+
+{% block search %}{% endblock %}
+{% block buttons %}{% endblock %}
+{% block base_javascript %}{% endblock %}
+{% block left_content %}&nbsp;{% endblock %}
+{% block before_content %}&nbsp;{% endblock %}
+{% block middle_content %}<h1>This service is down for maintenance</h1>{% endblock %}
+
+

--- a/cla_frontend/urls.py
+++ b/cla_frontend/urls.py
@@ -14,4 +14,5 @@ urlpatterns = patterns(
     url(r"^services/timing/", include("django_statsd.urls")),
     url(r"^status/", include("status.urls")),
     url(r"^", include("legalaid.urls", namespace="legalaid")),
+    url(r"^", include("core.urls", namespace="cla_backend_core")),
 ) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## What does this pull request do?

Add maintenance page
Insert new blocks into base template to allow extending templates to customise content

## Any other changes that would benefit highlighting?

The maintenance page returns a 503 status code. This will allow angular request to display an error message if the site is put in maintenance mode whilst still on page

/status/ping.json is exempt from being redirected when in maintenance mode, if not then the loadbalancer healthchecks will fail and the instance will be taken out of routing

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
