### PR TITLE
LGA-1383 - Reduce `startBuffer` for callback picker

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/directives/callbackModal.js
+++ b/cla_frontend/assets-src/javascripts/app/js/directives/callbackModal.js
@@ -7,7 +7,7 @@
 
   mod.directive('callbackModal', ['AppSettings', 'moment', 'postal', '$timeout', 'ClaPostalService', 'hotkeys', 'flash', 'form_utils', '$state', function (AppSettings, moment, postal, $timeout, ClaPostalService, hotkeys, flash, form_utils, $state) {
     var timeRounding = 30 * 60 * 1000; // to nearest 30 mins
-    var startBuffer = 120; // in mins
+    var startBuffer = 30; // in mins
 
     return {
       restrict: 'E',

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,2 +1,2 @@
 flake8>=3.6.0
-black>=18.9b0
+black==19.10b0


### PR DESCRIPTION
## What does this pull request do?
Reduces it to 30 minutes ie causing it to show the first window starting
more than half an hour away. This currently can't be reduced to zero (to
show the next window from now) or made negative (to show the current
window) as the backend will not allow scheduling callbacks at those
times

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
