### PR TITLE
LGA-1423 - Update cla_common for restored operator hours

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-widget-tweaks==1.3
 slumber==0.6.2
 python-dateutil==2.4.0
 
-git+git://github.com/ministryofjustice/cla_common.git@0.3.9#egg=cla_common
+git+git://github.com/ministryofjustice/cla_common.git@0.3.10#egg=cla_common
 
 django-proxy==1.0.2
 django-csp==2.0.3


### PR DESCRIPTION
## What does this pull request do?
cla_common has been updated with [new operator hours](https://github.com/ministryofjustice/cla_common/pull/98)
This PR updates cla_frontend to use that version of the library, and thus the new hours. It should not be merged until we're ready to deploy this behavioural change.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"