### PR TITLE
LGA-365 Scrolling Down

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -205,31 +205,3 @@
     .config(common_config)
     .run(common_run);
 })();
-
-if($("#wrapper")[0]) {
-  var target = $("#wrapper")[0];
-
-  var config = {
-    childList: true
-  };
-
-  var callback = function(mutationsList, observer) {
-    var pillsSectionList = document.getElementById("pills-section-list");
-    if (pillsSectionList) {
-      observer.disconnect();
-      $(".Pills-pillLink").click(function(){
-        var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $("header").height();
-        $([document.documentElement, document.body]).animate({
-          scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
-        }, 0);
-      });
-    }
-  }
-
-  var observer = new MutationObserver(callback);
-
-  observer.observe(target, config);
-}
-
-
-

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -206,25 +206,30 @@
     .run(common_run);
 })();
 
-var target = $("#wrapper")[0];
+if($("#wrapper"))
+{
+  var target = $("#wrapper")[0];
 
-var config = {
-  childList: true
-};
+  var config = {
+    childList: true
+  };
 
-function callback(mutationsList, observer) {
-  var pillsSectionList = document.getElementById('pills-section-list');
-  if (pillsSectionList) {
-    observer.disconnect();
-    $(".Pills-pillLink").click(function(){
-      var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $('header').height();
-      $([document.documentElement, document.body]).animate({
-        scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
-      }, 0);
-    });
-  }
-};
+  function callback(mutationsList, observer) {
+    var pillsSectionLismt = document.getElementById('pills-section-list');
+    if (pillsSectionList) {
+      observer.disconnect();
+      $(".Pills-pillLink").click(function(){
+        var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $('header').height();
+        $([document.documentElement, document.body]).animate({
+          scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
+        }, 0);
+      });
+    }
+  };
 
-var observer = new MutationObserver(callback);
+  var observer = new MutationObserver(callback);
 
-observer.observe(target, config);
+  observer.observe(target, config);
+}
+
+

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -206,8 +206,7 @@
     .run(common_run);
 })();
 
-if($("#wrapper")[0])
-{
+if($("#wrapper")[0]) {
   var target = $("#wrapper")[0];
 
   var config = {

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -205,3 +205,82 @@
     .config(common_config)
     .run(common_run);
 })();
+
+var testAppearTmr = setInterval(function() {
+    if ($('#pills-section-list').length) {
+      clearInterval(testAppearTmr);
+      console.log("Periodic checks");
+      console.log("Length: " + $(".Pills-pillLink").length);
+    } else {
+      console.log("Periodic checks - nothing found");
+    }
+}, 250);
+$('#pills-section-list').on("load",function(){
+  console.log("jQuery on load");
+  console.log("Length: " + $(".Pills-pillLink").length);
+});
+document.addEventListener('load', function(){
+  console.log('JS event listener load');
+  console.log("Length: " + $(".Pills-pillLink").length);
+});
+/*
+// The node to be monitored
+var target = $("#wrapper>div[ui-view]")[0];
+
+// Create an observer instance
+var observer = new MutationObserver(function(mutations, observer) {
+    // look through all mutations that just occured
+    for(var i=0; i<mutations.length; ++i) {
+        // look through all added nodes of this mutation
+        for(var j=0; j<mutations[i].addedNodes.length; ++j) {
+            // was a child added with class of 'Pills-pillLink'?
+            if(mutations[i].addedNodes[j].className == "Pills-pillLink") {
+              console.log('Mutation detect (method ii)');
+              console.log("Length: " + $(".Pills-pillLink").length);
+            } else {
+              console.log('Mutation detect (method ii) - nothing');
+            }
+        }
+    }
+});
+
+// Configuration of the observer:
+var config = {
+  subtree:true,
+  attributes: false,
+  childList: true,
+  characterData: true
+};
+
+// Pass in the target node, as well as the observer options
+observer.observe(target, config);
+*/
+const callback = function(mutationsList, observer) {
+    // Use traditional 'for loops' for IE 11
+    for(const mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+           console.log('Mutation detect (method ii)');
+           console.log(mutation.addedNodes[0])
+           console.log(mutation.target);
+        }
+    }
+};
+// Create an observer instance linked to the callback function
+const observer = new MutationObserver(callback);
+// Start observing the target node for configured mutations
+observer.observe(targetNode, config);
+
+
+/*
+var testAppearTmr = setInterval(function() {
+    if ($('#pills-section-list').length) {
+      clearInterval(testAppearTmr);
+      $(".Pills-pillLink").click(function(){
+        var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $('header').height();
+        $([document.documentElement, document.body]).animate({
+          scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
+        }, 0);
+      });
+    }
+}, 250);
+*/

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -206,7 +206,7 @@
     .run(common_run);
 })();
 
-if($("#wrapper"))
+if($("#wrapper")[0])
 {
   var target = $("#wrapper")[0];
 

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -206,81 +206,25 @@
     .run(common_run);
 })();
 
-var testAppearTmr = setInterval(function() {
-    if ($('#pills-section-list').length) {
-      clearInterval(testAppearTmr);
-      console.log("Periodic checks");
-      console.log("Length: " + $(".Pills-pillLink").length);
-    } else {
-      console.log("Periodic checks - nothing found");
-    }
-}, 250);
-$('#pills-section-list').on("load",function(){
-  console.log("jQuery on load");
-  console.log("Length: " + $(".Pills-pillLink").length);
-});
-document.addEventListener('load', function(){
-  console.log('JS event listener load');
-  console.log("Length: " + $(".Pills-pillLink").length);
-});
-/*
-// The node to be monitored
-var target = $("#wrapper>div[ui-view]")[0];
+var target = $("#wrapper")[0];
 
-// Create an observer instance
-var observer = new MutationObserver(function(mutations, observer) {
-    // look through all mutations that just occured
-    for(var i=0; i<mutations.length; ++i) {
-        // look through all added nodes of this mutation
-        for(var j=0; j<mutations[i].addedNodes.length; ++j) {
-            // was a child added with class of 'Pills-pillLink'?
-            if(mutations[i].addedNodes[j].className == "Pills-pillLink") {
-              console.log('Mutation detect (method ii)');
-              console.log("Length: " + $(".Pills-pillLink").length);
-            } else {
-              console.log('Mutation detect (method ii) - nothing');
-            }
-        }
-    }
-});
-
-// Configuration of the observer:
 var config = {
-  subtree:true,
-  attributes: false,
-  childList: true,
-  characterData: true
+  childList: true
 };
 
-// Pass in the target node, as well as the observer options
+function callback(mutationsList, observer) {
+  var pillsSectionList = document.getElementById('pills-section-list');
+  if (pillsSectionList) {
+    observer.disconnect();
+    $(".Pills-pillLink").click(function(){
+      var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $('header').height();
+      $([document.documentElement, document.body]).animate({
+        scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
+      }, 0);
+    });
+  }
+};
+
+var observer = new MutationObserver(callback);
+
 observer.observe(target, config);
-*/
-const callback = function(mutationsList, observer) {
-    // Use traditional 'for loops' for IE 11
-    for(const mutation of mutationsList) {
-        if (mutation.type === 'childList') {
-           console.log('Mutation detect (method ii)');
-           console.log(mutation.addedNodes[0])
-           console.log(mutation.target);
-        }
-    }
-};
-// Create an observer instance linked to the callback function
-const observer = new MutationObserver(callback);
-// Start observing the target node for configured mutations
-observer.observe(targetNode, config);
-
-
-/*
-var testAppearTmr = setInterval(function() {
-    if ($('#pills-section-list').length) {
-      clearInterval(testAppearTmr);
-      $(".Pills-pillLink").click(function(){
-        var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $('header').height();
-        $([document.documentElement, document.body]).animate({
-          scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
-        }, 0);
-      });
-    }
-}, 250);
-*/

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -214,22 +214,23 @@ if($("#wrapper"))
     childList: true
   };
 
-  function callback(mutationsList, observer) {
-    var pillsSectionLismt = document.getElementById('pills-section-list');
+  var callback = function(mutationsList, observer) {
+    var pillsSectionList = document.getElementById("pills-section-list");
     if (pillsSectionList) {
       observer.disconnect();
       $(".Pills-pillLink").click(function(){
-        var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $('header').height();
+        var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $("header").height();
         $([document.documentElement, document.body]).animate({
           scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
         }, 0);
       });
     }
-  };
+  }
 
   var observer = new MutationObserver(callback);
 
   observer.observe(target, config);
 }
+
 
 

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/diagnosis.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/diagnosis.js
@@ -34,6 +34,25 @@
             $scope.diagnosis.$move_down({
               'case_reference': $scope.case.reference
             }, saveCallback);
+
+            // Mutation observer used to detect when form element has been changed
+            // Due to new question (elements) being added and old question (elements) being removed
+            var form = document.querySelector('form[name="diagnosis-form"]');
+
+            var config = {
+              childList: true
+            };
+
+            var callback = function(mutationsList, observer) {
+              observer.disconnect()
+              // Only scroll after form questions have been added to the form or removed
+              form.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'start' });
+              return;
+            };
+
+            var observer = new MutationObserver(callback);
+
+            observer.observe(form, config);
           };
 
           $scope.moveUp = function() {

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/diagnosis.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/diagnosis.js
@@ -39,7 +39,7 @@
             // Due to new question (elements) being added and old question (elements) being removed
             var form = document.querySelector('form[name="diagnosis-form"]')
 
-            // Element is placed 100px under the form buttons using CSS
+            // Element is placed 100px under the form buttons using CSS in _case.scss
             // To ensure user doesn't have to scroll to find the button
             var anchorScroll = document.getElementById('anchor-scroll');
 

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/diagnosis.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/diagnosis.js
@@ -76,6 +76,9 @@
                 topic   : 'Log.refresh'
               });
             });
+
+            // Scroll to the top of the screen in case button is hidden from previous scrolling
+            scrollTo(0,0);
           };
 
           // if choices.length === 1 => check it by default

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/diagnosis.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/diagnosis.js
@@ -37,16 +37,19 @@
 
             // Mutation observer used to detect when form element has been changed
             // Due to new question (elements) being added and old question (elements) being removed
-            var form = document.querySelector('form[name="diagnosis-form"]');
+            var form = document.querySelector('form[name="diagnosis-form"]')
+
+            // Element is placed 100px under the form buttons using CSS
+            // To ensure user doesn't have to scroll to find the button
+            var anchorScroll = document.getElementById('anchor-scroll');
 
             var config = {
               childList: true
             };
 
             var callback = function(mutationsList, observer) {
-              observer.disconnect()
-              // Only scroll after form questions have been added to the form or removed
-              form.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'start' });
+              observer.disconnect();
+              anchorScroll.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'start' });
               return;
             };
 

--- a/cla_frontend/assets-src/javascripts/app/js/states/case_detail.edit.eligibility.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states/case_detail.edit.eligibility.js
@@ -15,7 +15,7 @@
         function(eligibility_check, diagnosis, EligibilityCheckService){
           EligibilityCheckService.onEnter(eligibility_check, diagnosis);
 
-          var target = $("#wrapper")[0];
+          var target = $('#wrapper')[0];
 
           var config = {
             childList: true,
@@ -23,17 +23,17 @@
           };
 
           var callback = function(mutationsList, observer) {
-            var pillsSectionList = document.getElementById("pills-section-list");
+            var pillsSectionList = document.getElementById('pills-section-list');
             if (pillsSectionList) {
-              observer.disconnect()
-              $(".Pills-pillLink").click(function(){
-                var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $("header").height();
+              observer.disconnect();
+              $('.Pills-pillLink').click(function(){
+                var heightHeaderAndCaseBar = $('.CaseBar').height()*2*!$('.CaseBar.is-sticky').length + $('header').height();
                 $([document.documentElement, document.body]).animate({
-                  scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
+                  scrollTop: ($('#pills-section-list').offset().top - heightHeaderAndCaseBar)
                 }, 0);
               });
             }
-          }
+          };
 
           var observer = new MutationObserver(callback);
 

--- a/cla_frontend/assets-src/javascripts/app/js/states/case_detail.edit.eligibility.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states/case_detail.edit.eligibility.js
@@ -14,6 +14,31 @@
       onEnter: ['eligibility_check', 'diagnosis', 'EligibilityCheckService',
         function(eligibility_check, diagnosis, EligibilityCheckService){
           EligibilityCheckService.onEnter(eligibility_check, diagnosis);
+
+          var target = $("#wrapper")[0];
+
+          var config = {
+            childList: true,
+            subtree: true
+          };
+
+          var callback = function(mutationsList, observer) {
+            var pillsSectionList = document.getElementById("pills-section-list");
+            if (pillsSectionList) {
+              observer.disconnect()
+              $(".Pills-pillLink").click(function(){
+                var heightHeaderAndCaseBar = $(".CaseBar").height()*2*!$(".CaseBar.is-sticky").length + $("header").height();
+                $([document.documentElement, document.body]).animate({
+                  scrollTop: ($("#pills-section-list").offset().top - heightHeaderAndCaseBar)
+                }, 0);
+              });
+            }
+          }
+
+          var observer = new MutationObserver(callback);
+
+          observer.observe(target, config);
+
         }],
       views: {
         '@case_detail.edit': {

--- a/cla_frontend/assets-src/javascripts/app/partials/case_detail.edit.diagnosis.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/case_detail.edit.diagnosis.html
@@ -39,4 +39,6 @@
     <a ui-sref="case_detail.edit.eligibility" class="Button" ng-if="diagnosis.isInScopeTrue() && !diagnosis.hasLetterOfProceedings()">Create financial assessment</a>
     <button type="button" name="diagnosis-delete" class="Button Button--secondary" ng-really-message="Are you sure you want to delete the diagnosis?" ng-really-click="delete()" ng-if="diagnosis.version_in_conflict || diagnosis.isInScopeTrue() || diagnosis.isInScopeFalse()">Delete scope diagnosis</button>
   </div>
+
+  <div id="anchor-scroll"></div>
 </form>

--- a/cla_frontend/assets-src/javascripts/app/partials/case_detail.edit.eligibility.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/case_detail.edit.eligibility.html
@@ -5,7 +5,7 @@
 </div>
 <form ng-submit="save()" ng-if="!eligibility_check.has_passported_proceedings_letter" novalidate name="form" class="Form-eligibility u-relative" form-changed>
   <div class="Toolbar clearfix">
-    <ul class="Pills u-pullLeft">
+    <ul id="pills-section-list" class="Pills u-pullLeft">
       <li class="Pills-pill {{ tabWarningClass(section) }}" ng-repeat="section in sections"
           ng-class="{'is-active': currentState() === section.state}">
         <a href="" ng-click="gotoSection(section)" class="Pills-pillLink">{{ ::section.title }}</a>

--- a/cla_frontend/assets-src/stylesheets/views/_case.scss
+++ b/cla_frontend/assets-src/stylesheets/views/_case.scss
@@ -49,3 +49,8 @@
     border: 10px solid #1D70B8;
     padding: 8px;
 }
+
+#anchor-scroll {
+  position: relative;
+  top: 30px;
+}


### PR DESCRIPTION
## What does this pull request do?

- **Finances part of the form:** Scrolls down to just above whatever inner tab has been selected under the `Finances` tab
- **Scope part of the form:** Scrolls down and ensures the questionnaire is in full view every time you click the 'next' button under the `Scope` tab

## Any other changes that would benefit highlighting?

Comments have been added to understand why mutation observer is used and how it works for the scope functionality in the `cla_frontend/assets-src/javascripts/app/js/states/case_detail.edit.eligibility.js` file

### Scope part of the form

 When I checked the dimensions (height) of the form in the code and after in the browser when reaching the last stage (ie. the `Delete scope diagnosis` button is present, it would be different. Believe this is due to some JS/angular scripts running, but I do not know entirely why.

**How it looks like:**

![image](https://user-images.githubusercontent.com/64010092/101361342-c36ecb00-3896-11eb-951b-30f51fff6e2c.png)

(_Every time the next button is clicked, the page scrolls to where the red bar is in the image above. The bar is set to always be below the present button. I set the background colour to red and with a height of10 px for explaining purposes. It is invisible in staging/production with a height of 0px and full width_)

> Please visit staging and check out the functionality there

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
