### PR TITLE
LGA-1506 - Replace raven Python library with Sentry SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN chown -R www-data:www-data /var/lib/nginx && \
     chown www-data:www-data /etc/nginx/conf.d/htpassword
 
 # Pip install Python packages
-RUN pip install -U pip
+RUN pip install -U pip==18.1
 RUN pip install -U setuptools wheel
 RUN pip install GitPython uwsgi
 
@@ -92,7 +92,7 @@ RUN npm install
 
 # Install front-end dependencies
 COPY .bowerrc bower.json ./
-RUN npm run bower 
+RUN npm run bower
 
 # Build front-end assets
 COPY tasks/ ./tasks

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,6 @@
     "angularUtils": "michaelbromley/angularUtils#c6275a699ba580b66a02e7a922fe169ef9b6c61c",
     "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",
     "fullcalendar": "1.6.4",
-    "raven-js": "1.1.16",
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "moment-timezone": "~0.3.1",
     "angular-sticky": "angular-sticky-plugin#^0.4.2",

--- a/cla_frontend/apps/core/context_processors.py
+++ b/cla_frontend/apps/core/context_processors.py
@@ -8,7 +8,7 @@ def globals(request):
         "phase": "alpha",
         "product_type": "service",
         "feedback_url": "#",
-        "raven_config_site": settings.RAVEN_CONFIG["site"] or "",
+        "raven_config_site": "",
         "socketio_server_url": settings.SOCKETIO_SERVER_URL,
         "analytics_id": settings.ANALYTICS_ID,
         "analytics_domain": settings.ANALYTICS_DOMAIN,

--- a/cla_frontend/apps/status/views.py
+++ b/cla_frontend/apps/status/views.py
@@ -9,8 +9,6 @@ from .smoketests import smoketests
 
 
 def status(request):
-    if "error" in request.GET.keys():
-        raise Exception("ISSUE: %s" % datetime.datetime.now())
     results = list(smoketests.execute())
     passed = reduce(lambda acc, curr: acc and curr["status"], results, True)
 
@@ -36,7 +34,5 @@ class PingJsonView(View):
     """
 
     def get(self, request):
-        if "error" in request.GET.keys():
-            raise Exception("ISSUE: %s" % datetime.datetime.now())
         response_data = {"build_tag": None, "build_date": None, "version_number": None, "commit_id": None}
         return JsonResponse(response_data)

--- a/cla_frontend/apps/status/views.py
+++ b/cla_frontend/apps/status/views.py
@@ -9,6 +9,8 @@ from .smoketests import smoketests
 
 
 def status(request):
+    if "error" in request.GET.keys():
+        raise Exception("ISSUE: %s" % datetime.datetime.now())
     results = list(smoketests.execute())
     passed = reduce(lambda acc, curr: acc and curr["status"], results, True)
 
@@ -34,5 +36,7 @@ class PingJsonView(View):
     """
 
     def get(self, request):
+        if "error" in request.GET.keys():
+            raise Exception("ISSUE: %s" % datetime.datetime.now())
         response_data = {"build_tag": None, "build_date": None, "version_number": None, "commit_id": None}
         return JsonResponse(response_data)

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -2,6 +2,9 @@ import sys
 import os
 from os.path import join, abspath, dirname
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
 # PATH vars
 
 here = lambda *x: join(abspath(dirname(__file__)), *x)
@@ -165,7 +168,6 @@ INSTALLED_APPS = (
     "django_statsd",
     "widget_tweaks",
     "session_security",
-    "raven.contrib.django.raven_compat",
 )
 
 PROJECT_APPS = ("cla_auth", "cla_common", "core", "legalaid", "call_centre", "cla_provider", "status")
@@ -234,7 +236,13 @@ SESSION_SECURITY_PASSIVE_URLS = []
 SESSION_SECURITY_PASSIVE_HEADER = "HTTP__PASSIVE"
 SESSION_SECURITY_PASSIVE_QUERYSTRING = "_passive"
 
-RAVEN_CONFIG = {"dsn": os.environ.get("RAVEN_CONFIG_DSN", ""), "site": os.environ.get("RAVEN_CONFIG_SITE", "")}
+if "SENTRY_DSN" in os.environ:
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        integrations=[DjangoIntegrations()],
+        traces_sample_rate=1.0,
+        environment=os.environ.get("CLA_ENV", "unknown")
+    )
 
 SOCKETIO_SERVER_URL = os.environ.get("SOCKETIO_SERVER_URL", "http://localhost:8005/socket.io")
 SITE_HOSTNAME = os.environ.get("SITE_HOSTNAME", "localhost")
@@ -246,12 +254,6 @@ ZENDESK_API_TOKEN = os.environ.get("ZENDESK_API_TOKEN", "")
 ZENDESK_REQUESTER_ID = os.environ.get("ZENDESK_REQUESTER_ID", 762871298)  # Defaults to 'Civil Legal Advice' user
 ZENDESK_GROUP_ID = os.environ.get("ZENDESK_GROUP_ID", 24287107)  # Defaults to 'CLA Operator/Provider' group
 ZENDESK_API_ENDPOINT = "https://ministryofjustice.zendesk.com/api/v2/"
-
-if "RAVEN_CONFIG_DSN" in os.environ:
-    MIDDLEWARE_CLASSES = (
-        "raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware",
-        #'raven.contrib.django.raven_compat.middleware.Sentry404CatchMiddleware',
-    ) + MIDDLEWARE_CLASSES
 
 
 OS_PLACES_API_KEY = os.environ.get("OS_PLACES_API_KEY")

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -239,7 +239,7 @@ SESSION_SECURITY_PASSIVE_QUERYSTRING = "_passive"
 if "SENTRY_DSN" in os.environ:
     sentry_sdk.init(
         dsn=os.environ.get("SENTRY_DSN"),
-        integrations=[DjangoIntegrations()],
+        integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
         environment=os.environ.get("CLA_ENV", "unknown"),
     )

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -241,7 +241,7 @@ if "SENTRY_DSN" in os.environ:
         dsn=os.environ.get("SENTRY_DSN"),
         integrations=[DjangoIntegrations()],
         traces_sample_rate=1.0,
-        environment=os.environ.get("CLA_ENV", "unknown")
+        environment=os.environ.get("CLA_ENV", "unknown"),
     )
 
 SOCKETIO_SERVER_URL = os.environ.get("SOCKETIO_SERVER_URL", "http://localhost:8005/socket.io")

--- a/cla_frontend/templates/base.html
+++ b/cla_frontend/templates/base.html
@@ -1,12 +1,10 @@
-{% load staticfiles core_tags raven %}
+{% load staticfiles core_tags %}
 <!DOCTYPE html>
 <html lang="en" {% block html_attrs %}ng-csp{% endblock %}
   data-analytics-id="{{ analytics_id }}"
   data-analytics-domain="{{ analytics_domain }}">
 
-  <head data-sentry-dsn="{% sentry_public_dsn %}"
-    data-sentry-site="{{ raven_config_site }}"
-    data-socketio-server="{{ socketio_server_url }}">
+  <head data-socketio-server="{{ socketio_server_url }}">
     <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -23,9 +21,6 @@
     <link href="{% staticmin 'stylesheets/cla.main.css' %}" media="screen" rel="stylesheet">
     <!-- print styles -->
     <link href="{% staticmin 'stylesheets/cla.print.css' %}" media="print" rel="stylesheet" type="text/css" />
-
-    <script src="{% static 'javascripts/vendor/raven.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'javascripts/vendor/raven.config.js' %}"></script>
 
     {% if not debug %}
     <script type="text/javascript" src="{% static 'javascripts/vendor/boomerang/boomerang.js' %}"></script>

--- a/cla_frontend/wsgi.py
+++ b/cla_frontend/wsgi.py
@@ -18,11 +18,10 @@ from os.path import abspath, dirname
 from sys import path
 
 from django.core.wsgi import get_wsgi_application
-from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
 
 SITE_ROOT = dirname(dirname(abspath(__file__)))
 path.append(SITE_ROOT)
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cla_frontend.settings")
 
-application = Sentry(get_wsgi_application())
+application = get_wsgi_application()

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
       "integrity": "sha1-+Kt+H4QYzmPNput713ioXX7EkrI=",
       "dev": true,
       "requires": {
-        "CSSwhat": "0.4",
-        "domutils": "1.4"
+        "CSSwhat": "0.4.7",
+        "domutils": "1.4.3"
       }
     },
     "CSSwhat": {
@@ -39,8 +39,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "abbrev": {
@@ -55,7 +55,7 @@
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.11",
+        "mime-types": "2.1.17",
         "negotiator": "0.6.1"
       },
       "dependencies": {
@@ -71,7 +71,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "~1.30.0"
+            "mime-db": "1.30.0"
           }
         }
       }
@@ -100,8 +100,8 @@
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
+        "extend": "3.0.1",
+        "semver": "5.0.3"
       },
       "dependencies": {
         "semver": {
@@ -118,10 +118,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "alter": {
@@ -130,7 +130,7 @@
       "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
       "dev": true,
       "requires": {
-        "stable": "~0.1.3"
+        "stable": "0.1.6"
       }
     },
     "amdefine": {
@@ -146,11 +146,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bitsyntax": "~0.0.4",
-        "bluebird": "^3.4.6",
+        "bitsyntax": "0.0.4",
+        "bluebird": "3.5.1",
         "buffer-more-ints": "0.0.2",
-        "readable-stream": "1.x >=1.1.9",
-        "safe-buffer": "^5.0.1"
+        "readable-stream": "1.1.14",
+        "safe-buffer": "5.1.1"
       }
     },
     "angular": {
@@ -168,8 +168,8 @@
       "resolved": "https://registry.npmjs.org/angular-blocks/-/angular-blocks-0.1.15.tgz",
       "integrity": "sha1-ZUwPVa63XJ+4zuDlKnTBKUrnV7Q=",
       "requires": {
-        "angular": "^1.6.7 < 2.0.0",
-        "jquery": "^1.11.1"
+        "angular": "1.6.8",
+        "jquery": "1.12.4"
       },
       "dependencies": {
         "abbrev": {
@@ -182,7 +182,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "requires": {
-            "mime-types": "~2.1.11",
+            "mime-types": "2.1.17",
             "negotiator": "0.6.1"
           }
         },
@@ -196,8 +196,8 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "align-text": {
@@ -205,9 +205,9 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
           }
         },
         "amdefine": {
@@ -239,8 +239,8 @@
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
           "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
           "requires": {
-            "micromatch": "^2.1.5",
-            "normalize-path": "^2.0.0"
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
           }
         },
         "argparse": {
@@ -248,7 +248,7 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
           "requires": {
-            "sprintf-js": "~1.0.2"
+            "sprintf-js": "1.0.3"
           }
         },
         "arr-diff": {
@@ -256,7 +256,7 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "arr-flatten": {
@@ -355,7 +355,7 @@
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "better-assert": {
@@ -387,15 +387,15 @@
           "integrity": "sha512-KL2pZpGvy6xuZHgYUznB1Zfw4AoGMApfRanT5NafeLvglbaSM+4CCtmlyYOv66oYXqvKL1xpaFb94V/AZVUnYg==",
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "debug": "2.6.8",
-            "depd": "~1.1.1",
-            "http-errors": "~1.6.2",
+            "depd": "1.1.1",
+            "http-errors": "1.6.2",
             "iconv-lite": "0.4.19",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "~1.6.15"
+            "type-is": "1.6.15"
           },
           "dependencies": {
             "iconv-lite": {
@@ -415,7 +415,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
@@ -423,7 +423,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -432,9 +432,9 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "browserify-zlib": {
@@ -442,7 +442,7 @@
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
-            "pako": "~0.2.0"
+            "pako": "0.2.9"
           }
         },
         "builtin-modules": {
@@ -470,8 +470,8 @@
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "caseless": {
@@ -484,8 +484,8 @@
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
           }
         },
         "chai": {
@@ -493,9 +493,9 @@
           "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
           "requires": {
-            "assertion-error": "^1.0.1",
-            "deep-eql": "^0.1.3",
-            "type-detect": "^1.0.0"
+            "assertion-error": "1.0.2",
+            "deep-eql": "0.1.3",
+            "type-detect": "1.0.0"
           }
         },
         "chalk": {
@@ -503,11 +503,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "chokidar": {
@@ -515,15 +515,15 @@
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "requires": {
-            "anymatch": "^1.3.0",
-            "async-each": "^1.0.0",
-            "fsevents": "^1.0.0",
-            "glob-parent": "^2.0.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^2.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0"
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.1.3",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
           }
         },
         "cli": {
@@ -532,7 +532,7 @@
           "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
           "requires": {
             "exit": "0.1.2",
-            "glob": "^7.1.1"
+            "glob": "7.1.2"
           },
           "dependencies": {
             "glob": {
@@ -540,12 +540,12 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "minimatch": {
@@ -553,7 +553,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               }
             }
           }
@@ -563,8 +563,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -588,7 +588,7 @@
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "commander": {
@@ -621,9 +621,9 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
           },
           "dependencies": {
             "isarray": {
@@ -636,13 +636,13 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
               "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.0.3",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
               }
             },
             "string_decoder": {
@@ -650,7 +650,7 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -662,7 +662,7 @@
           "requires": {
             "debug": "2.6.8",
             "finalhandler": "1.0.4",
-            "parseurl": "~1.3.1",
+            "parseurl": "1.3.2",
             "utils-merge": "1.0.0"
           }
         },
@@ -671,7 +671,7 @@
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "requires": {
-            "date-now": "^0.1.4"
+            "date-now": "0.1.4"
           }
         },
         "content-type": {
@@ -711,7 +711,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "currently-unhandled": {
@@ -719,7 +719,7 @@
           "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
           "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
           "requires": {
-            "array-find-index": "^1.0.1"
+            "array-find-index": "1.0.2"
           }
         },
         "custom-event": {
@@ -732,7 +732,7 @@
           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -805,10 +805,10 @@
           "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
           "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
           "requires": {
-            "custom-event": "~1.0.0",
-            "ent": "~2.2.0",
-            "extend": "^3.0.0",
-            "void-elements": "^2.0.0"
+            "custom-event": "1.0.1",
+            "ent": "2.2.0",
+            "extend": "3.0.1",
+            "void-elements": "2.0.1"
           }
         },
         "dom-serializer": {
@@ -816,8 +816,8 @@
           "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
           "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
           "requires": {
-            "domelementtype": "~1.1.1",
-            "entities": "~1.1.1"
+            "domelementtype": "1.1.3",
+            "entities": "1.1.1"
           },
           "dependencies": {
             "domelementtype": {
@@ -842,7 +842,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
           "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "domutils": {
@@ -850,8 +850,8 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
+            "dom-serializer": "0.1.0",
+            "domelementtype": "1.3.0"
           }
         },
         "ecc-jsbn": {
@@ -860,7 +860,7 @@
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "ee-first": {
@@ -943,8 +943,8 @@
               "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
               "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
               "requires": {
-                "options": ">=0.0.5",
-                "ultron": "1.0.x"
+                "options": "0.0.6",
+                "ultron": "1.0.2"
               }
             }
           }
@@ -977,7 +977,7 @@
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "requires": {
-            "is-arrayish": "^0.2.1"
+            "is-arrayish": "0.2.1"
           }
         },
         "es6-promise": {
@@ -1000,11 +1000,11 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
           "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
           "requires": {
-            "esprima": "^2.7.1",
-            "estraverse": "^1.9.1",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.2.0"
+            "esprima": "2.7.3",
+            "estraverse": "1.9.3",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.2.0"
           },
           "dependencies": {
             "source-map": {
@@ -1013,7 +1013,7 @@
               "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
               "optional": true,
               "requires": {
-                "amdefine": ">=0.0.4"
+                "amdefine": "1.0.1"
               }
             }
           }
@@ -1053,9 +1053,9 @@
           "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
           "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
           "requires": {
-            "array-slice": "^0.2.3",
-            "array-unique": "^0.2.1",
-            "braces": "^0.1.2"
+            "array-slice": "0.2.3",
+            "array-unique": "0.2.1",
+            "braces": "0.1.5"
           },
           "dependencies": {
             "braces": {
@@ -1063,7 +1063,7 @@
               "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
               "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
               "requires": {
-                "expand-range": "^0.1.0"
+                "expand-range": "0.1.1"
               }
             },
             "expand-range": {
@@ -1071,8 +1071,8 @@
               "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
               "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
               "requires": {
-                "is-number": "^0.1.1",
-                "repeat-string": "^0.2.2"
+                "is-number": "0.1.1",
+                "repeat-string": "0.2.2"
               }
             },
             "is-number": {
@@ -1092,7 +1092,7 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "expand-range": {
@@ -1100,7 +1100,7 @@
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "requires": {
-            "fill-range": "^2.1.0"
+            "fill-range": "2.2.3"
           }
         },
         "extend": {
@@ -1113,7 +1113,7 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "extract-zip": {
@@ -1170,7 +1170,7 @@
           "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
           "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
           "requires": {
-            "pend": "~1.2.0"
+            "pend": "1.2.0"
           }
         },
         "figures": {
@@ -1178,8 +1178,8 @@
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "filename-regex": {
@@ -1192,8 +1192,8 @@
           "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
           "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
           "requires": {
-            "glob": "3.x",
-            "minimatch": "0.x"
+            "glob": "3.1.21",
+            "minimatch": "0.2.14"
           }
         },
         "fill-range": {
@@ -1201,11 +1201,11 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^1.1.3",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "finalhandler": {
@@ -1214,12 +1214,12 @@
           "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
           "requires": {
             "debug": "2.6.8",
-            "encodeurl": "~1.0.1",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.1",
-            "statuses": "~1.3.1",
-            "unpipe": "~1.0.0"
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
           }
         },
         "find-up": {
@@ -1227,8 +1227,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "findup-sync": {
@@ -1236,8 +1236,8 @@
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
           "requires": {
-            "glob": "~3.2.9",
-            "lodash": "~2.4.1"
+            "glob": "3.2.11",
+            "lodash": "2.4.2"
           },
           "dependencies": {
             "glob": {
@@ -1245,8 +1245,8 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
               "requires": {
-                "inherits": "2",
-                "minimatch": "0.3"
+                "inherits": "2.0.3",
+                "minimatch": "0.3.0"
               }
             },
             "lodash": {
@@ -1259,8 +1259,8 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
               "requires": {
-                "lru-cache": "2",
-                "sigmund": "~1.0.0"
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
               }
             }
           }
@@ -1275,7 +1275,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "forever-agent": {
@@ -1288,9 +1288,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
           }
         },
         "formatio": {
@@ -1298,7 +1298,7 @@
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
           "requires": {
-            "samsam": "~1.1"
+            "samsam": "1.1.2"
           }
         },
         "fs-access": {
@@ -1306,7 +1306,7 @@
           "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
           "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
           "requires": {
-            "null-check": "^1.0.0"
+            "null-check": "1.0.0"
           }
         },
         "fs-extra": {
@@ -1314,9 +1314,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1"
           },
           "dependencies": {
             "graceful-fs": {
@@ -1337,8 +1337,8 @@
           "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
           "optional": true,
           "requires": {
-            "nan": "^2.3.0",
-            "node-pre-gyp": "^0.6.39"
+            "nan": "2.8.0",
+            "node-pre-gyp": "0.6.39"
           },
           "dependencies": {
             "abbrev": {
@@ -1353,8 +1353,8 @@
               "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
               "optional": true,
               "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
               }
             },
             "ansi-regex": {
@@ -1374,8 +1374,8 @@
               "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "optional": true,
               "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.2.9"
               }
             },
             "asn1": {
@@ -1419,7 +1419,7 @@
               "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
               "optional": true,
               "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
               }
             },
             "block-stream": {
@@ -1427,7 +1427,7 @@
               "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
               "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
               "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
               }
             },
             "boom": {
@@ -1435,7 +1435,7 @@
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
               "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
               }
             },
             "brace-expansion": {
@@ -1443,7 +1443,7 @@
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
               "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
               "requires": {
-                "balanced-match": "^0.4.1",
+                "balanced-match": "0.4.2",
                 "concat-map": "0.0.1"
               }
             },
@@ -1474,7 +1474,7 @@
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
               }
             },
             "concat-map": {
@@ -1497,7 +1497,7 @@
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
               "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
               "requires": {
-                "boom": "2.x.x"
+                "boom": "2.10.1"
               }
             },
             "dashdash": {
@@ -1506,7 +1506,7 @@
               "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
               "optional": true,
               "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -1555,7 +1555,7 @@
               "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
               "optional": true,
               "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
               }
             },
             "extend": {
@@ -1581,9 +1581,9 @@
               "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
               "optional": true,
               "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
               }
             },
             "fs.realpath": {
@@ -1596,10 +1596,10 @@
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
               "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
               }
             },
             "fstream-ignore": {
@@ -1608,9 +1608,9 @@
               "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "optional": true,
               "requires": {
-                "fstream": "^1.0.0",
-                "inherits": "2",
-                "minimatch": "^3.0.0"
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
               }
             },
             "gauge": {
@@ -1619,14 +1619,14 @@
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "optional": true,
               "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.1.1",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
               }
             },
             "getpass": {
@@ -1635,7 +1635,7 @@
               "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
               "optional": true,
               "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -1651,12 +1651,12 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "graceful-fs": {
@@ -1676,8 +1676,8 @@
               "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
               "optional": true,
               "requires": {
-                "ajv": "^4.9.1",
-                "har-schema": "^1.0.5"
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
               }
             },
             "has-unicode": {
@@ -1691,10 +1691,10 @@
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
               }
             },
             "hoek": {
@@ -1708,9 +1708,9 @@
               "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "optional": true,
               "requires": {
-                "assert-plus": "^0.2.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.0"
               }
             },
             "inflight": {
@@ -1718,8 +1718,8 @@
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
               }
             },
             "inherits": {
@@ -1738,7 +1738,7 @@
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "is-typedarray": {
@@ -1764,7 +1764,7 @@
               "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
               "optional": true,
               "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
               }
             },
             "jsbn": {
@@ -1785,7 +1785,7 @@
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "optional": true,
               "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
               }
             },
             "json-stringify-safe": {
@@ -1830,7 +1830,7 @@
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
               "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
               "requires": {
-                "mime-db": "~1.27.0"
+                "mime-db": "1.27.0"
               }
             },
             "minimatch": {
@@ -1838,7 +1838,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.7"
               }
             },
             "minimist": {
@@ -1866,17 +1866,17 @@
               "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
               "optional": true,
               "requires": {
-                "detect-libc": "^1.0.2",
+                "detect-libc": "1.0.2",
                 "hawk": "3.1.3",
-                "mkdirp": "^0.5.1",
-                "nopt": "^4.0.1",
-                "npmlog": "^4.0.2",
-                "rc": "^1.1.7",
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.0",
+                "rc": "1.2.1",
                 "request": "2.81.0",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^2.2.1",
-                "tar-pack": "^3.4.0"
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.0"
               }
             },
             "nopt": {
@@ -1885,8 +1885,8 @@
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "optional": true,
               "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
               }
             },
             "npmlog": {
@@ -1895,10 +1895,10 @@
               "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
               "optional": true,
               "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
               }
             },
             "number-is-nan": {
@@ -1923,7 +1923,7 @@
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               }
             },
             "os-homedir": {
@@ -1944,8 +1944,8 @@
               "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "optional": true,
               "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
               }
             },
             "path-is-absolute": {
@@ -1982,10 +1982,10 @@
               "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
               "optional": true,
               "requires": {
-                "deep-extend": "~0.4.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -2001,13 +2001,13 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
               "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
               "requires": {
-                "buffer-shims": "~1.0.0",
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~1.0.0",
-                "util-deprecate": "~1.0.1"
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "1.0.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "request": {
@@ -2016,28 +2016,28 @@
               "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "optional": true,
               "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.0.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.0.1"
               }
             },
             "rimraf": {
@@ -2045,7 +2045,7 @@
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
               "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
               }
             },
             "safe-buffer": {
@@ -2076,7 +2076,7 @@
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
               "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
               "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
               }
             },
             "sshpk": {
@@ -2085,15 +2085,15 @@
               "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
               "optional": true,
               "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jodid25519": "^1.0.0",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jodid25519": "1.0.2",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
               },
               "dependencies": {
                 "assert-plus": {
@@ -2109,9 +2109,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             },
             "string_decoder": {
@@ -2119,7 +2119,7 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
               "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
               "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.0.1"
               }
             },
             "stringstream": {
@@ -2133,7 +2133,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               }
             },
             "strip-json-comments": {
@@ -2147,9 +2147,9 @@
               "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
               "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               }
             },
             "tar-pack": {
@@ -2158,14 +2158,14 @@
               "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
               "optional": true,
               "requires": {
-                "debug": "^2.2.0",
-                "fstream": "^1.0.10",
-                "fstream-ignore": "^1.0.5",
-                "once": "^1.3.3",
-                "readable-stream": "^2.1.4",
-                "rimraf": "^2.5.1",
-                "tar": "^2.2.1",
-                "uid-number": "^0.0.6"
+                "debug": "2.6.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.2.9",
+                "rimraf": "2.6.1",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
               }
             },
             "tough-cookie": {
@@ -2174,7 +2174,7 @@
               "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
               "optional": true,
               "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
               }
             },
             "tunnel-agent": {
@@ -2183,7 +2183,7 @@
               "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "optional": true,
               "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.0.1"
               }
             },
             "tweetnacl": {
@@ -2224,7 +2224,7 @@
               "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
               "optional": true,
               "requires": {
-                "string-width": "^1.0.2"
+                "string-width": "1.0.2"
               }
             },
             "wrappy": {
@@ -2239,8 +2239,8 @@
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
           "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
           "requires": {
-            "fileset": "~0.1.5",
-            "minimatch": "~0.2.9"
+            "fileset": "0.1.8",
+            "minimatch": "0.2.14"
           }
         },
         "generate-function": {
@@ -2253,7 +2253,7 @@
           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
           "requires": {
-            "is-property": "^1.0.0"
+            "is-property": "1.0.2"
           }
         },
         "get-stdin": {
@@ -2271,7 +2271,7 @@
           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2286,9 +2286,9 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
           },
           "dependencies": {
             "inherits": {
@@ -2303,8 +2303,8 @@
           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "requires": {
-            "glob-parent": "^2.0.0",
-            "is-glob": "^2.0.0"
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
           }
         },
         "glob-parent": {
@@ -2312,7 +2312,7 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "graceful-fs": {
@@ -2324,26 +2324,26 @@
           "version": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
           "integrity": "sha512-1iq3ylLjzXqz/KSq1OAE2qhnpcbkF2WyhsQcavZt+YmgvHu0EbPMEhGhy2gr0FP67isHpRdfwjB5WVeXXcJemQ==",
           "requires": {
-            "async": "~0.1.22",
-            "coffee-script": "~1.3.3",
-            "colors": "~0.6.2",
+            "async": "0.1.22",
+            "coffee-script": "1.3.3",
+            "colors": "0.6.2",
             "dateformat": "1.0.2-1.2.3",
-            "eventemitter2": "~0.4.13",
-            "exit": "~0.1.1",
-            "findup-sync": "~0.1.2",
-            "getobject": "~0.1.0",
-            "glob": "~3.1.21",
-            "grunt-legacy-log": "~0.1.0",
-            "grunt-legacy-util": "~0.2.0",
-            "hooker": "~0.2.3",
-            "iconv-lite": "~0.2.11",
-            "js-yaml": "~2.0.5",
-            "lodash": "~0.9.2",
-            "minimatch": "~0.2.12",
-            "nopt": "~1.0.10",
-            "rimraf": "~2.2.8",
-            "underscore.string": "~2.2.1",
-            "which": "~1.0.5"
+            "eventemitter2": "0.4.14",
+            "exit": "0.1.2",
+            "findup-sync": "0.1.3",
+            "getobject": "0.1.0",
+            "glob": "3.1.21",
+            "grunt-legacy-log": "0.1.3",
+            "grunt-legacy-util": "0.2.0",
+            "hooker": "0.2.3",
+            "iconv-lite": "0.2.11",
+            "js-yaml": "2.0.5",
+            "lodash": "0.9.2",
+            "minimatch": "0.2.14",
+            "nopt": "1.0.10",
+            "rimraf": "2.2.8",
+            "underscore.string": "2.2.1",
+            "which": "1.0.9"
           },
           "dependencies": {
             "argparse": {
@@ -2383,8 +2383,8 @@
           "resolved": "https://registry.npmjs.org/grunt-build-lifecycle/-/grunt-build-lifecycle-0.1.1.tgz",
           "integrity": "sha1-aEgu7cNRdqNN2A68HpSJsyyxCtg=",
           "requires": {
-            "underscore": "~1.4.4",
-            "underscore.string": "~2.3.1"
+            "underscore": "1.4.4",
+            "underscore.string": "2.3.3"
           },
           "dependencies": {
             "underscore": {
@@ -2404,8 +2404,8 @@
           "resolved": "https://registry.npmjs.org/grunt-bumpup/-/grunt-bumpup-0.6.3.tgz",
           "integrity": "sha1-dU6Wu2pTN9C5VInl3EmWuvyLtBQ=",
           "requires": {
-            "moment": "^2.8.3",
-            "semver": "^4.0.3"
+            "moment": "2.18.1",
+            "semver": "4.3.6"
           }
         },
         "grunt-contrib-concat": {
@@ -2413,8 +2413,8 @@
           "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
           "integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
           "requires": {
-            "chalk": "^1.0.0",
-            "source-map": "^0.5.3"
+            "chalk": "1.1.3",
+            "source-map": "0.5.7"
           }
         },
         "grunt-contrib-jshint": {
@@ -2422,9 +2422,9 @@
           "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.0.0.tgz",
           "integrity": "sha1-MPQFpR3mVr+m6wKbmkZLn+AqQCo=",
           "requires": {
-            "chalk": "^1.1.1",
-            "hooker": "^0.2.3",
-            "jshint": "~2.9.1"
+            "chalk": "1.1.3",
+            "hooker": "0.2.3",
+            "jshint": "2.9.5"
           }
         },
         "grunt-contrib-uglify": {
@@ -2432,11 +2432,11 @@
           "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.2.tgz",
           "integrity": "sha1-rmekb5FT7dTLEYE6Vetpxw19svs=",
           "requires": {
-            "chalk": "^1.0.0",
-            "lodash": "^4.0.1",
-            "maxmin": "^1.1.0",
-            "uglify-js": "~2.6.2",
-            "uri-path": "^1.0.0"
+            "chalk": "1.1.3",
+            "lodash": "4.17.4",
+            "maxmin": "1.1.0",
+            "uglify-js": "2.6.4",
+            "uri-path": "1.0.0"
           },
           "dependencies": {
             "lodash": {
@@ -2456,7 +2456,7 @@
           "resolved": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-0.12.2.tgz",
           "integrity": "sha1-1SZ2q5R3nksgBStfNRnrMmU9xWY=",
           "requires": {
-            "lodash": "^3.10.1"
+            "lodash": "3.10.1"
           },
           "dependencies": {
             "lodash": {
@@ -2471,11 +2471,11 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
           "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
           "requires": {
-            "colors": "~0.6.2",
-            "grunt-legacy-log-utils": "~0.1.1",
-            "hooker": "~0.2.3",
-            "lodash": "~2.4.1",
-            "underscore.string": "~2.3.3"
+            "colors": "0.6.2",
+            "grunt-legacy-log-utils": "0.1.1",
+            "hooker": "0.2.3",
+            "lodash": "2.4.2",
+            "underscore.string": "2.3.3"
           },
           "dependencies": {
             "lodash": {
@@ -2495,9 +2495,9 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
           "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
           "requires": {
-            "colors": "~0.6.2",
-            "lodash": "~2.4.1",
-            "underscore.string": "~2.3.3"
+            "colors": "0.6.2",
+            "lodash": "2.4.2",
+            "underscore.string": "2.3.3"
           },
           "dependencies": {
             "lodash": {
@@ -2517,13 +2517,13 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
           "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
           "requires": {
-            "async": "~0.1.22",
-            "exit": "~0.1.1",
-            "getobject": "~0.1.0",
-            "hooker": "~0.2.3",
-            "lodash": "~0.9.2",
-            "underscore.string": "~2.2.1",
-            "which": "~1.0.5"
+            "async": "0.1.22",
+            "exit": "0.1.2",
+            "getobject": "0.1.0",
+            "hooker": "0.2.3",
+            "lodash": "0.9.2",
+            "underscore.string": "2.2.1",
+            "which": "1.0.9"
           }
         },
         "grunt-regarde": {
@@ -2531,7 +2531,7 @@
           "resolved": "https://registry.npmjs.org/grunt-regarde/-/grunt-regarde-0.1.1.tgz",
           "integrity": "sha1-bLnYfMbIrwNeBcWIEimpiE+8QLg=",
           "requires": {
-            "gaze": "~0.3.1"
+            "gaze": "0.3.4"
           }
         },
         "gzip-size": {
@@ -2539,8 +2539,8 @@
           "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
           "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
           "requires": {
-            "browserify-zlib": "^0.1.4",
-            "concat-stream": "^1.4.1"
+            "browserify-zlib": "0.1.4",
+            "concat-stream": "1.6.0"
           }
         },
         "handlebars": {
@@ -2548,10 +2548,10 @@
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
           "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
           "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.6.4"
           },
           "dependencies": {
             "async": {
@@ -2564,7 +2564,7 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "requires": {
-                "amdefine": ">=0.0.4"
+                "amdefine": "1.0.1"
               }
             }
           }
@@ -2579,10 +2579,10 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
+            "chalk": "1.1.3",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.16.1",
+            "pinkie-promise": "2.0.1"
           }
         },
         "has-ansi": {
@@ -2590,7 +2590,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "has-binary": {
@@ -2616,8 +2616,8 @@
           "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
           "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
           "requires": {
-            "is-stream": "^1.0.1",
-            "pinkie-promise": "^2.0.0"
+            "is-stream": "1.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "hawk": {
@@ -2625,10 +2625,10 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -2651,11 +2651,11 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "requires": {
-            "domelementtype": "1",
-            "domhandler": "2.3",
-            "domutils": "1.5",
-            "entities": "1.0",
-            "readable-stream": "1.1"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.3.0",
+            "domutils": "1.5.1",
+            "entities": "1.0.0",
+            "readable-stream": "1.1.14"
           }
         },
         "http-errors": {
@@ -2666,7 +2666,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.3.1"
           }
         },
         "http-proxy": {
@@ -2674,8 +2674,8 @@
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
           "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
           "requires": {
-            "eventemitter3": "1.x.x",
-            "requires-port": "1.x.x"
+            "eventemitter3": "1.2.0",
+            "requires-port": "1.0.0"
           }
         },
         "http-signature": {
@@ -2683,9 +2683,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
         "iconv-lite": {
@@ -2698,7 +2698,7 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "indexof": {
@@ -2711,8 +2711,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -2730,7 +2730,7 @@
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "requires": {
-            "binary-extensions": "^1.0.0"
+            "binary-extensions": "1.10.0"
           }
         },
         "is-buffer": {
@@ -2743,7 +2743,7 @@
           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "requires": {
-            "builtin-modules": "^1.0.0"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-dotfile": {
@@ -2756,7 +2756,7 @@
           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "requires": {
-            "is-primitive": "^2.0.0"
+            "is-primitive": "2.0.0"
           }
         },
         "is-extendable": {
@@ -2774,7 +2774,7 @@
           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-glob": {
@@ -2782,7 +2782,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-my-json-valid": {
@@ -2790,10 +2790,10 @@
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
           "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
           "requires": {
-            "generate-function": "^2.0.0",
-            "generate-object-property": "^1.1.0",
-            "jsonpointer": "^4.0.0",
-            "xtend": "^4.0.0"
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "jsonpointer": "4.0.1",
+            "xtend": "4.0.1"
           }
         },
         "is-number": {
@@ -2801,7 +2801,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-posix-bracket": {
@@ -2874,20 +2874,20 @@
           "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
           "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
           "requires": {
-            "abbrev": "1.0.x",
-            "async": "1.x",
-            "escodegen": "1.8.x",
-            "esprima": "2.7.x",
-            "glob": "^5.0.15",
-            "handlebars": "^4.0.1",
-            "js-yaml": "3.x",
-            "mkdirp": "0.5.x",
-            "nopt": "3.x",
-            "once": "1.x",
-            "resolve": "1.1.x",
-            "supports-color": "^3.1.0",
-            "which": "^1.1.1",
-            "wordwrap": "^1.0.0"
+            "abbrev": "1.0.9",
+            "async": "1.5.2",
+            "escodegen": "1.8.1",
+            "esprima": "2.7.3",
+            "glob": "5.0.15",
+            "handlebars": "4.0.10",
+            "js-yaml": "3.6.1",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "once": "1.4.0",
+            "resolve": "1.1.7",
+            "supports-color": "3.2.3",
+            "which": "1.3.0",
+            "wordwrap": "1.0.0"
           },
           "dependencies": {
             "abbrev": {
@@ -2905,11 +2905,11 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
               "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "minimatch": {
@@ -2917,7 +2917,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               }
             },
             "nopt": {
@@ -2925,7 +2925,7 @@
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.0.9"
               }
             },
             "supports-color": {
@@ -2933,7 +2933,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "1.0.0"
               }
             },
             "which": {
@@ -2941,7 +2941,7 @@
               "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
               "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
               "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
               }
             },
             "wordwrap": {
@@ -2966,8 +2966,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^2.6.0"
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
           }
         },
         "jsbn": {
@@ -2981,14 +2981,14 @@
           "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
           "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
           "requires": {
-            "cli": "~1.0.0",
-            "console-browserify": "1.1.x",
-            "exit": "0.1.x",
-            "htmlparser2": "3.8.x",
-            "lodash": "3.7.x",
-            "minimatch": "~3.0.2",
-            "shelljs": "0.3.x",
-            "strip-json-comments": "1.0.x"
+            "cli": "1.0.1",
+            "console-browserify": "1.1.0",
+            "exit": "0.1.2",
+            "htmlparser2": "3.8.3",
+            "lodash": "3.7.0",
+            "minimatch": "3.0.4",
+            "shelljs": "0.3.0",
+            "strip-json-comments": "1.0.4"
           },
           "dependencies": {
             "lodash": {
@@ -3001,7 +3001,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               }
             }
           }
@@ -3016,7 +3016,7 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -3034,7 +3034,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           },
           "dependencies": {
             "graceful-fs": {
@@ -3078,29 +3078,29 @@
           "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
           "integrity": "sha1-B3ULG9Bj1+fnuRvNLmNU2PKqh0Q=",
           "requires": {
-            "batch": "^0.5.3",
-            "bluebird": "^2.9.27",
-            "body-parser": "^1.12.4",
-            "chokidar": "^1.4.1",
-            "colors": "^1.1.0",
-            "connect": "^3.3.5",
-            "core-js": "^2.1.0",
-            "di": "^0.0.1",
-            "dom-serialize": "^2.2.0",
-            "expand-braces": "^0.1.1",
-            "glob": "^7.0.0",
-            "graceful-fs": "^4.1.2",
-            "http-proxy": "^1.13.0",
-            "isbinaryfile": "^3.0.0",
-            "lodash": "^3.8.0",
-            "log4js": "^0.6.31",
-            "mime": "^1.3.4",
-            "minimatch": "^3.0.0",
-            "optimist": "^0.6.1",
-            "rimraf": "^2.3.3",
-            "socket.io": "^1.4.5",
-            "source-map": "^0.5.3",
-            "useragent": "^2.1.6"
+            "batch": "0.5.3",
+            "bluebird": "2.11.0",
+            "body-parser": "1.18.1",
+            "chokidar": "1.7.0",
+            "colors": "1.1.2",
+            "connect": "3.6.3",
+            "core-js": "2.5.1",
+            "di": "0.0.1",
+            "dom-serialize": "2.2.1",
+            "expand-braces": "0.1.2",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "http-proxy": "1.16.2",
+            "isbinaryfile": "3.0.2",
+            "lodash": "3.10.1",
+            "log4js": "0.6.38",
+            "mime": "1.4.0",
+            "minimatch": "3.0.4",
+            "optimist": "0.6.1",
+            "rimraf": "2.6.2",
+            "socket.io": "1.7.4",
+            "source-map": "0.5.7",
+            "useragent": "2.2.1"
           },
           "dependencies": {
             "colors": {
@@ -3113,12 +3113,12 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "graceful-fs": {
@@ -3136,7 +3136,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               }
             },
             "rimraf": {
@@ -3144,7 +3144,7 @@
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
               "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
               "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
               }
             }
           }
@@ -3154,8 +3154,8 @@
           "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.3.tgz",
           "integrity": "sha1-TG1wDRY6nTTGGO/YeRi+SeekqMk=",
           "requires": {
-            "fs-access": "^1.0.0",
-            "which": "^1.2.1"
+            "fs-access": "1.0.1",
+            "which": "1.3.0"
           },
           "dependencies": {
             "which": {
@@ -3163,7 +3163,7 @@
               "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
               "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
               "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
               }
             }
           }
@@ -3173,7 +3173,7 @@
           "resolved": "https://registry.npmjs.org/karma-coffee-preprocessor/-/karma-coffee-preprocessor-0.3.0.tgz",
           "integrity": "sha1-pNjcKxRb/vRYogPTCLY7wDybQlk=",
           "requires": {
-            "coffee-script": "~1"
+            "coffee-script": "1.3.3"
           }
         },
         "karma-coverage": {
@@ -3181,10 +3181,10 @@
           "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.5.5.tgz",
           "integrity": "sha1-sNWLECXVnVxmICYxhvHVj11TSMU=",
           "requires": {
-            "dateformat": "^1.0.6",
-            "istanbul": "^0.4.0",
-            "minimatch": "^3.0.0",
-            "source-map": "^0.5.1"
+            "dateformat": "1.0.12",
+            "istanbul": "0.4.5",
+            "minimatch": "3.0.4",
+            "source-map": "0.5.7"
           },
           "dependencies": {
             "dateformat": {
@@ -3192,8 +3192,8 @@
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
               "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
               "requires": {
-                "get-stdin": "^4.0.1",
-                "meow": "^3.3.0"
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
               }
             },
             "minimatch": {
@@ -3201,7 +3201,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               }
             }
           }
@@ -3226,7 +3226,7 @@
           "resolved": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-0.4.2.tgz",
           "integrity": "sha1-SSojZyj+TJKqz0GfzQEQpDJ+nX8=",
           "requires": {
-            "path-is-absolute": "^1.0.0",
+            "path-is-absolute": "1.0.1",
             "xmlbuilder": "3.1.0"
           }
         },
@@ -3245,8 +3245,8 @@
           "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.3.tgz",
           "integrity": "sha1-Edy8mlYlHRjmjt9wuW05lkc0G1g=",
           "requires": {
-            "lodash": "^4.0.1",
-            "phantomjs-prebuilt": "^2.1.7"
+            "lodash": "4.17.4",
+            "phantomjs-prebuilt": "2.1.15"
           },
           "dependencies": {
             "lodash": {
@@ -3276,7 +3276,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         },
         "klaw": {
@@ -3284,7 +3284,7 @@
           "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
           "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
           "requires": {
-            "graceful-fs": "^4.1.9"
+            "graceful-fs": "4.1.11"
           },
           "dependencies": {
             "graceful-fs": {
@@ -3310,8 +3310,8 @@
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
           }
         },
         "load-json-file": {
@@ -3319,11 +3319,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           },
           "dependencies": {
             "graceful-fs": {
@@ -3348,8 +3348,8 @@
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
           "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
           "requires": {
-            "readable-stream": "~1.0.2",
-            "semver": "~4.3.3"
+            "readable-stream": "1.0.34",
+            "semver": "4.3.6"
           },
           "dependencies": {
             "readable-stream": {
@@ -3357,10 +3357,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             }
           }
@@ -3380,8 +3380,8 @@
           "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
           "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
           "requires": {
-            "currently-unhandled": "^0.4.1",
-            "signal-exit": "^3.0.0"
+            "currently-unhandled": "0.4.1",
+            "signal-exit": "3.0.2"
           }
         },
         "lru-cache": {
@@ -3399,9 +3399,9 @@
           "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-1.0.1.tgz",
           "integrity": "sha1-pXozgESR+64girqPaDgEN6vC3KU=",
           "requires": {
-            "findup-sync": "~0.3.0",
-            "micromatch": "^2.3.7",
-            "resolve": "~1.1.6",
+            "findup-sync": "0.3.0",
+            "micromatch": "2.3.11",
+            "resolve": "1.1.7",
             "stack-trace": "0.0.9"
           },
           "dependencies": {
@@ -3410,7 +3410,7 @@
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
               "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
               "requires": {
-                "glob": "~5.0.0"
+                "glob": "5.0.15"
               }
             },
             "glob": {
@@ -3418,11 +3418,11 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
               "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               }
             },
             "minimatch": {
@@ -3430,7 +3430,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               }
             }
           }
@@ -3440,10 +3440,10 @@
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
           "requires": {
-            "chalk": "^1.0.0",
-            "figures": "^1.0.1",
-            "gzip-size": "^1.0.0",
-            "pretty-bytes": "^1.0.0"
+            "chalk": "1.1.3",
+            "figures": "1.7.0",
+            "gzip-size": "1.0.0",
+            "pretty-bytes": "1.0.4"
           }
         },
         "media-typer": {
@@ -3456,16 +3456,16 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "micromatch": {
@@ -3473,19 +3473,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "mime": {
@@ -3503,7 +3503,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "requires": {
-            "mime-db": "~1.30.0"
+            "mime-db": "1.30.0"
           }
         },
         "minimatch": {
@@ -3511,8 +3511,8 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         },
         "minimist": {
@@ -3561,7 +3561,7 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1.1.1"
           }
         },
         "normalize-package-data": {
@@ -3569,10 +3569,10 @@
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "4.3.6",
+            "validate-npm-package-license": "3.0.1"
           }
         },
         "normalize-path": {
@@ -3580,7 +3580,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         },
         "null-check": {
@@ -3613,8 +3613,8 @@
           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "requires": {
-            "for-own": "^0.1.4",
-            "is-extendable": "^0.1.1"
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
           }
         },
         "on-finished": {
@@ -3630,7 +3630,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "optimist": {
@@ -3638,8 +3638,8 @@
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.2"
           },
           "dependencies": {
             "minimist": {
@@ -3654,12 +3654,12 @@
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
           "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.4",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "wordwrap": "~1.0.0"
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
           },
           "dependencies": {
             "wordwrap": {
@@ -3689,10 +3689,10 @@
           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "requires": {
-            "glob-base": "^0.3.0",
-            "is-dotfile": "^1.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.0"
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
           }
         },
         "parse-json": {
@@ -3700,7 +3700,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "parsejson": {
@@ -3708,7 +3708,7 @@
           "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
           "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
           "requires": {
-            "better-assert": "~1.0.0"
+            "better-assert": "1.0.2"
           }
         },
         "parseqs": {
@@ -3716,7 +3716,7 @@
           "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
           "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
           "requires": {
-            "better-assert": "~1.0.0"
+            "better-assert": "1.0.2"
           }
         },
         "parseuri": {
@@ -3724,7 +3724,7 @@
           "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
           "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
           "requires": {
-            "better-assert": "~1.0.0"
+            "better-assert": "1.0.2"
           }
         },
         "parseurl": {
@@ -3737,7 +3737,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
@@ -3750,9 +3750,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           },
           "dependencies": {
             "graceful-fs": {
@@ -3777,15 +3777,15 @@
           "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz",
           "integrity": "sha1-IPhugtM0nFBZF1J3RbekEeCLOQM=",
           "requires": {
-            "es6-promise": "~4.0.3",
-            "extract-zip": "~1.6.5",
-            "fs-extra": "~1.0.0",
-            "hasha": "~2.2.0",
-            "kew": "~0.7.0",
-            "progress": "~1.1.8",
-            "request": "~2.81.0",
-            "request-progress": "~2.0.1",
-            "which": "~1.2.10"
+            "es6-promise": "4.0.5",
+            "extract-zip": "1.6.5",
+            "fs-extra": "1.0.0",
+            "hasha": "2.2.0",
+            "kew": "0.7.0",
+            "progress": "1.1.8",
+            "request": "2.81.0",
+            "request-progress": "2.0.1",
+            "which": "1.2.14"
           },
           "dependencies": {
             "caseless": {
@@ -3798,8 +3798,8 @@
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
               "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
               "requires": {
-                "ajv": "^4.9.1",
-                "har-schema": "^1.0.5"
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
               }
             },
             "qs": {
@@ -3812,28 +3812,28 @@
               "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
               "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
               }
             },
             "tunnel-agent": {
@@ -3841,7 +3841,7 @@
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
               "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
               }
             },
             "which": {
@@ -3849,7 +3849,7 @@
               "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
               "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
               "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
               }
             }
           }
@@ -3869,7 +3869,7 @@
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "prelude-ls": {
@@ -3887,8 +3887,8 @@
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
           "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.1.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "process-nextick-args": {
@@ -3916,8 +3916,8 @@
           "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
           "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -3925,7 +3925,7 @@
               "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -3933,7 +3933,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.5"
                   }
                 }
               }
@@ -3943,7 +3943,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.5"
               }
             }
           }
@@ -3971,9 +3971,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -3981,8 +3981,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "readable-stream": {
@@ -3990,10 +3990,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "readdirp": {
@@ -4001,10 +4001,10 @@
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
           "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "minimatch": "^3.0.2",
-            "readable-stream": "^2.0.2",
-            "set-immediate-shim": "^1.0.1"
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "readable-stream": "2.3.3",
+            "set-immediate-shim": "1.0.1"
           },
           "dependencies": {
             "graceful-fs": {
@@ -4022,7 +4022,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               }
             },
             "readable-stream": {
@@ -4030,13 +4030,13 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
               "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.0.3",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
               }
             },
             "string_decoder": {
@@ -4044,7 +4044,7 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -4054,8 +4054,8 @@
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "regex-cache": {
@@ -4063,7 +4063,7 @@
           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
           "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "requires": {
-            "is-equal-shallow": "^0.1.3"
+            "is-equal-shallow": "0.1.3"
           }
         },
         "remove-trailing-separator": {
@@ -4086,7 +4086,7 @@
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "requires": {
-            "is-finite": "^1.0.0"
+            "is-finite": "1.0.2"
           }
         },
         "request": {
@@ -4094,26 +4094,26 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
           }
         },
         "request-progress": {
@@ -4121,7 +4121,7 @@
           "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
           "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
           "requires": {
-            "throttleit": "^1.0.0"
+            "throttleit": "1.0.0"
           }
         },
         "requirejs": {
@@ -4144,7 +4144,7 @@
           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "requires": {
-            "align-text": "^0.1.1"
+            "align-text": "0.1.4"
           }
         },
         "rimraf": {
@@ -4200,7 +4200,7 @@
             "formatio": "1.1.1",
             "lolex": "1.3.2",
             "samsam": "1.1.2",
-            "util": ">=0.10.3 <1"
+            "util": "0.10.3"
           }
         },
         "sinon-chai": {
@@ -4213,7 +4213,7 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "socket.io": {
@@ -4222,7 +4222,7 @@
           "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
           "requires": {
             "debug": "2.3.3",
-            "engine.io": "~1.8.4",
+            "engine.io": "1.8.4",
             "has-binary": "0.1.7",
             "object-assign": "4.1.0",
             "socket.io-adapter": "0.5.0",
@@ -4283,7 +4283,7 @@
             "component-bind": "1.0.0",
             "component-emitter": "1.2.1",
             "debug": "2.3.3",
-            "engine.io-client": "~1.8.4",
+            "engine.io-client": "1.8.4",
             "has-binary": "0.1.7",
             "indexof": "0.0.1",
             "object-component": "0.0.3",
@@ -4348,7 +4348,7 @@
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "requires": {
-            "spdx-license-ids": "^1.0.2"
+            "spdx-license-ids": "1.2.2"
           }
         },
         "spdx-expression-parse": {
@@ -4371,14 +4371,14 @@
           "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
           "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "assert-plus": {
@@ -4413,7 +4413,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-bom": {
@@ -4421,7 +4421,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-indent": {
@@ -4429,7 +4429,7 @@
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "strip-json-comments": {
@@ -4452,7 +4452,7 @@
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         },
         "to-array": {
@@ -4465,7 +4465,7 @@
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         },
         "trim-newlines": {
@@ -4489,7 +4489,7 @@
           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "requires": {
-            "prelude-ls": "~1.1.2"
+            "prelude-ls": "1.1.2"
           }
         },
         "type-detect": {
@@ -4503,7 +4503,7 @@
           "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "~2.1.15"
+            "mime-types": "2.1.17"
           }
         },
         "typedarray": {
@@ -4516,10 +4516,10 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
           "requires": {
-            "async": "~0.2.6",
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "async": "0.2.10",
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "async": {
@@ -4564,8 +4564,8 @@
           "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
           "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
           "requires": {
-            "lru-cache": "2.2.x",
-            "tmp": "0.0.x"
+            "lru-cache": "2.2.4",
+            "tmp": "0.0.33"
           },
           "dependencies": {
             "lru-cache": {
@@ -4610,8 +4610,8 @@
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "requires": {
-            "spdx-correct": "~1.0.0",
-            "spdx-expression-parse": "~1.0.0"
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
           }
         },
         "verror": {
@@ -4619,9 +4619,9 @@
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "requires": {
-            "assert-plus": "^1.0.0",
+            "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "extsprintf": "1.3.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -4661,8 +4661,8 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
           "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
           "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
+            "options": "0.0.6",
+            "ultron": "1.0.2"
           }
         },
         "wtf-8": {
@@ -4675,7 +4675,7 @@
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
           "integrity": "sha1-LIaIjy1OrehQ+jjKf3Ij9yCVFuE=",
           "requires": {
-            "lodash": "^3.5.0"
+            "lodash": "3.10.1"
           },
           "dependencies": {
             "lodash": {
@@ -4700,9 +4700,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           },
           "dependencies": {
@@ -4718,7 +4718,7 @@
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "requires": {
-            "fd-slicer": "~1.0.1"
+            "fd-slicer": "1.0.1"
           }
         },
         "yeast": {
@@ -4763,7 +4763,7 @@
       "resolved": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.2.0.tgz",
       "integrity": "sha512-0jm7AfCTk/zbBuVuoz9MecMplGfTQ9Wk9JB8J4qYX9IddcETRukpbKXMy27YTL1wKwYJkRTbGMu/Pb3IXbMfyA==",
       "requires": {
-        "moment": ">=2.8.0 <3.0.0"
+        "moment": "2.20.1"
       }
     },
     "angular-resource": {
@@ -4791,7 +4791,7 @@
       "resolved": "https://registry.npmjs.org/angular-xeditable/-/angular-xeditable-0.8.1.tgz",
       "integrity": "sha512-L4AkM18NDKL1M/vumZxSfMm+IGO/tWDIDjy0tk9qo5TO4zGH4R8Z1g+IelewUPR3KvLPhkXUcZsIY+wjMnOTaw==",
       "requires": {
-        "angular": "~1.x"
+        "angular": "1.6.8"
       }
     },
     "angulartics": {
@@ -4805,7 +4805,7 @@
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "^0.1.0"
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-cyan": {
@@ -4859,8 +4859,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -4869,7 +4869,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -4884,9 +4884,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "expand-brackets": {
@@ -4895,7 +4895,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -4904,7 +4904,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -4919,7 +4919,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -4928,7 +4928,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -4937,19 +4937,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         }
       }
@@ -4966,7 +4966,7 @@
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "dev": true,
       "requires": {
-        "file-type": "^3.1.0"
+        "file-type": "3.9.0"
       },
       "dependencies": {
         "file-type": {
@@ -4989,8 +4989,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -5005,13 +5005,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -5020,7 +5020,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -5031,7 +5031,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -5100,7 +5100,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -5126,9 +5126,9 @@
       "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "assert": {
@@ -5165,7 +5165,7 @@
       "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.3"
+        "acorn": "4.0.13"
       },
       "dependencies": {
         "acorn": {
@@ -5183,7 +5183,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "4.17.4"
       }
     },
     "async-each": {
@@ -5272,13 +5272,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.0",
+        "pascalcase": "0.1.1"
       }
     },
     "base64-arraybuffer": {
@@ -5311,7 +5311,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -5335,13 +5335,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "archive-type": "^3.0.1",
-        "decompress": "^3.0.0",
-        "download": "^4.1.2",
-        "exec-series": "^1.0.0",
-        "rimraf": "^2.2.6",
-        "tempfile": "^1.0.0",
-        "url-regex": "^3.0.0"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "download": "4.4.3",
+        "exec-series": "1.0.3",
+        "rimraf": "2.2.8",
+        "tempfile": "1.1.1",
+        "url-regex": "3.2.0"
       },
       "dependencies": {
         "tempfile": {
@@ -5351,8 +5351,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-tmpdir": "^1.0.0",
-            "uuid": "^2.0.1"
+            "os-tmpdir": "1.0.2",
+            "uuid": "2.0.3"
           }
         },
         "uuid": {
@@ -5371,7 +5371,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "executable": "^1.0.0"
+        "executable": "1.1.0"
       }
     },
     "bin-version": {
@@ -5381,7 +5381,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "find-versions": "^1.0.0"
+        "find-versions": "1.2.1"
       }
     },
     "bin-version-check": {
@@ -5391,10 +5391,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-version": "^1.0.0",
-        "minimist": "^1.1.0",
-        "semver": "^4.0.3",
-        "semver-truncate": "^1.0.0"
+        "bin-version": "1.0.4",
+        "minimist": "1.2.0",
+        "semver": "4.3.6",
+        "semver-truncate": "1.1.2"
       }
     },
     "bin-wrapper": {
@@ -5404,12 +5404,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-check": "^2.0.0",
-        "bin-version-check": "^2.1.0",
-        "download": "^4.0.0",
-        "each-async": "^1.1.1",
-        "lazy-req": "^1.0.0",
-        "os-filter-obj": "^1.0.0"
+        "bin-check": "2.0.0",
+        "bin-version-check": "2.1.0",
+        "download": "4.4.3",
+        "each-async": "1.1.1",
+        "lazy-req": "1.1.0",
+        "os-filter-obj": "1.0.3"
       }
     },
     "binary-extensions": {
@@ -5445,7 +5445,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "bluebird": {
@@ -5467,15 +5467,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
+        "depd": "1.1.2",
+        "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "type-is": "1.6.15"
       },
       "dependencies": {
         "qs": {
@@ -5498,7 +5498,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.0"
       }
     },
     "bower": {
@@ -5513,7 +5513,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -5523,17 +5523,17 @@
       "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.1",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.1"
       }
     },
     "brorand": {
@@ -5548,12 +5548,12 @@
       "integrity": "sha512-Jo+RYsn8X8OhyP9tMXXg0ueR2fW696HUu1Hf3/DeiwNean1oGiPtdgGRNuUHBpPHzBH3x4n1kzAlgOgHSIq88g==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "combine-source-map": "~0.8.0",
-        "defined": "^1.0.0",
-        "safe-buffer": "^5.1.1",
-        "through2": "^2.0.0",
-        "umd": "^3.0.0"
+        "JSONStream": "1.3.2",
+        "combine-source-map": "0.8.0",
+        "defined": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "through2": "2.0.3",
+        "umd": "3.0.1"
       }
     },
     "browser-resolve": {
@@ -5579,16 +5579,16 @@
       "integrity": "sha512-GCYd5WAoshtyz2/Ycy3Nj4F7rGOCwsFZIegcpQ8iGkk24ZQDo9kFIRlHYWBTcDRnLqEM/Lst79fr5POz3qCzOA==",
       "dev": true,
       "requires": {
-        "browser-sync-ui": "v1.0.1",
+        "browser-sync-ui": "1.0.1",
         "bs-recipes": "1.3.4",
         "chokidar": "1.7.0",
         "connect": "3.5.0",
-        "connect-history-api-fallback": "^1.5.0",
-        "dev-ip": "^1.0.1",
+        "connect-history-api-fallback": "1.5.0",
+        "dev-ip": "1.0.1",
         "easy-extender": "2.3.2",
         "eazy-logger": "3.0.2",
-        "etag": "^1.8.1",
-        "fresh": "^0.5.2",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
         "immutable": "3.8.2",
@@ -5597,7 +5597,7 @@
         "opn": "4.0.2",
         "portscanner": "2.1.1",
         "qs": "6.2.3",
-        "raw-body": "^2.3.2",
+        "raw-body": "2.3.2",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
         "serve-index": "1.8.0",
@@ -5614,7 +5614,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -5629,9 +5629,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "connect": {
@@ -5640,9 +5640,9 @@
           "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
           "dev": true,
           "requires": {
-            "debug": "~2.2.0",
+            "debug": "2.2.0",
             "finalhandler": "0.5.0",
-            "parseurl": "~1.3.1",
+            "parseurl": "1.3.2",
             "utils-merge": "1.0.0"
           }
         },
@@ -5661,7 +5661,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -5670,7 +5670,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "finalhandler": {
@@ -5679,11 +5679,11 @@
           "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
           "dev": true,
           "requires": {
-            "debug": "~2.2.0",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "statuses": "~1.3.0",
-            "unpipe": "~1.0.0"
+            "debug": "2.2.0",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
           }
         },
         "fs-extra": {
@@ -5692,9 +5692,9 @@
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^3.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.1"
           }
         },
         "graceful-fs": {
@@ -5709,8 +5709,8 @@
           "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
           "dev": true,
           "requires": {
-            "eventemitter3": "1.x.x",
-            "requires-port": "1.x.x"
+            "eventemitter3": "1.2.0",
+            "requires-port": "1.0.0"
           }
         },
         "is-extglob": {
@@ -5725,7 +5725,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "jsonfile": {
@@ -5734,7 +5734,7 @@
           "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         },
         "kind-of": {
@@ -5743,7 +5743,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -5752,19 +5752,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "ms": {
@@ -5794,11 +5794,11 @@
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "^1.1.0",
-        "immutable": "^3.7.6",
+        "connect-history-api-fallback": "1.5.0",
+        "immutable": "3.8.2",
         "server-destroy": "1.0.1",
         "socket.io-client": "2.0.4",
-        "stream-throttle": "^0.1.3"
+        "stream-throttle": "0.1.3"
       },
       "dependencies": {
         "async-each-series": {
@@ -5815,53 +5815,53 @@
       "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "assert": "^1.4.0",
-        "browser-pack": "^6.0.1",
-        "browser-resolve": "^1.11.0",
-        "browserify-zlib": "~0.2.0",
-        "buffer": "^5.0.2",
-        "cached-path-relative": "^1.0.0",
-        "concat-stream": "~1.5.1",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "~1.0.0",
-        "crypto-browserify": "^3.0.0",
-        "defined": "^1.0.0",
-        "deps-sort": "^2.0.0",
-        "domain-browser": "~1.1.0",
-        "duplexer2": "~0.1.2",
-        "events": "~1.1.0",
-        "glob": "^7.1.0",
-        "has": "^1.0.0",
-        "htmlescape": "^1.1.0",
-        "https-browserify": "^1.0.0",
-        "inherits": "~2.0.1",
-        "insert-module-globals": "^7.0.0",
-        "labeled-stream-splicer": "^2.0.0",
-        "module-deps": "^4.0.8",
-        "os-browserify": "~0.3.0",
-        "parents": "^1.0.1",
-        "path-browserify": "~0.0.0",
-        "process": "~0.11.0",
-        "punycode": "^1.3.2",
-        "querystring-es3": "~0.2.0",
-        "read-only-stream": "^2.0.0",
-        "readable-stream": "^2.0.2",
-        "resolve": "^1.1.4",
-        "shasum": "^1.0.0",
-        "shell-quote": "^1.6.1",
-        "stream-browserify": "^2.0.0",
-        "stream-http": "^2.0.0",
-        "string_decoder": "~1.0.0",
-        "subarg": "^1.0.0",
-        "syntax-error": "^1.1.1",
-        "through2": "^2.0.0",
-        "timers-browserify": "^1.0.1",
-        "tty-browserify": "~0.0.0",
-        "url": "~0.11.0",
-        "util": "~0.10.1",
-        "vm-browserify": "~0.0.1",
-        "xtend": "^4.0.0"
+        "JSONStream": "1.3.2",
+        "assert": "1.4.1",
+        "browser-pack": "6.0.3",
+        "browser-resolve": "1.11.2",
+        "browserify-zlib": "0.2.0",
+        "buffer": "5.0.8",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "defined": "1.0.0",
+        "deps-sort": "2.0.0",
+        "domain-browser": "1.1.7",
+        "duplexer2": "0.1.4",
+        "events": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "htmlescape": "1.1.1",
+        "https-browserify": "1.0.0",
+        "inherits": "2.0.3",
+        "insert-module-globals": "7.0.1",
+        "labeled-stream-splicer": "2.0.0",
+        "module-deps": "4.1.1",
+        "os-browserify": "0.3.0",
+        "parents": "1.0.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "read-only-stream": "2.0.0",
+        "readable-stream": "2.3.3",
+        "resolve": "1.5.0",
+        "shasum": "1.0.2",
+        "shell-quote": "1.6.1",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.0",
+        "string_decoder": "1.0.3",
+        "subarg": "1.0.0",
+        "syntax-error": "1.3.0",
+        "through2": "2.0.3",
+        "timers-browserify": "1.4.2",
+        "tty-browserify": "0.0.1",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "concat-stream": {
@@ -5870,9 +5870,9 @@
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~2.0.0",
-            "typedarray": "~0.0.5"
+            "inherits": "2.0.3",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
           },
           "dependencies": {
             "readable-stream": {
@@ -5881,12 +5881,12 @@
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
               }
             },
             "string_decoder": {
@@ -5903,7 +5903,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.3"
           }
         },
         "glob": {
@@ -5912,12 +5912,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "isarray": {
@@ -5932,7 +5932,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "readable-stream": {
@@ -5941,13 +5941,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "shell-quote": {
@@ -5956,10 +5956,10 @@
           "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
           "dev": true,
           "requires": {
-            "array-filter": "~0.0.0",
-            "array-map": "~0.0.0",
-            "array-reduce": "~0.0.0",
-            "jsonify": "~0.0.0"
+            "array-filter": "0.0.1",
+            "array-map": "0.0.0",
+            "array-reduce": "0.0.0",
+            "jsonify": "0.0.0"
           }
         },
         "string_decoder": {
@@ -5968,7 +5968,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -5979,12 +5979,12 @@
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "browserify-cipher": {
@@ -5993,9 +5993,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.1.1",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -6004,9 +6004,9 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
       }
     },
     "browserify-rsa": {
@@ -6015,8 +6015,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -6025,13 +6025,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
       }
     },
     "browserify-zlib": {
@@ -6040,7 +6040,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.6"
       }
     },
     "bs-recipes": {
@@ -6055,8 +6055,8 @@
       "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "1.2.1",
+        "ieee754": "1.1.8"
       }
     },
     "buffer-crc32": {
@@ -6072,7 +6072,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-array-buffer-x": "^1.0.13"
+        "is-array-buffer-x": "1.7.0"
       }
     },
     "buffer-more-ints": {
@@ -6087,10 +6087,10 @@
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
       "dev": true,
       "requires": {
-        "file-type": "^3.1.0",
-        "readable-stream": "^2.0.2",
-        "uuid": "^2.0.1",
-        "vinyl": "^1.0.0"
+        "file-type": "3.9.0",
+        "readable-stream": "2.3.3",
+        "uuid": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "file-type": {
@@ -6111,13 +6111,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -6126,7 +6126,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "uuid": {
@@ -6141,8 +6141,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -6160,7 +6160,7 @@
       "integrity": "sha512-HaJnVuslRF4g2kSDeyl++AaVizoitCpL9PglzCYwy0uHHyvWerfvEb8jWmYbF1z4kiVFolGomnxSGl+GUQp2jg==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -6175,13 +6175,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -6190,7 +6190,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -6228,9 +6228,9 @@
       "resolved": "https://registry.npmjs.org/bullseye/-/bullseye-1.4.6.tgz",
       "integrity": "sha1-tz9gb3tCc76ArGWs11KV1iYG/iQ=",
       "requires": {
-        "crossvent": "^1.3.1",
+        "crossvent": "1.5.0",
         "seleccion": "2.0.0",
-        "sell": "^1.0.0"
+        "sell": "1.0.0"
       }
     },
     "bytes": {
@@ -6245,15 +6245,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "cached-constructors-x": {
@@ -6285,8 +6285,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "capture-stack-trace": {
@@ -6307,10 +6307,10 @@
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
       "dev": true,
       "requires": {
-        "get-proxy": "^1.0.1",
-        "is-obj": "^1.0.0",
-        "object-assign": "^3.0.0",
-        "tunnel-agent": "^0.4.0"
+        "get-proxy": "1.1.0",
+        "is-obj": "1.0.1",
+        "object-assign": "3.0.0",
+        "tunnel-agent": "0.4.3"
       },
       "dependencies": {
         "object-assign": {
@@ -6327,11 +6327,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "cheerio": {
@@ -6340,10 +6340,10 @@
       "integrity": "sha1-SK8RNFYbNSf4PZFWxPmo69grBuw=",
       "dev": true,
       "requires": {
-        "CSSselect": "~0.4.0",
-        "entities": "0.x",
-        "htmlparser2": "~3.4.0",
-        "underscore": "~1.5"
+        "CSSselect": "0.4.1",
+        "entities": "0.5.0",
+        "htmlparser2": "3.4.0",
+        "underscore": "1.5.2"
       }
     },
     "chokidar": {
@@ -6352,15 +6352,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.3",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -6369,7 +6369,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -6384,7 +6384,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -6395,8 +6395,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "circular-json": {
@@ -6411,10 +6411,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -6423,7 +6423,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -6432,7 +6432,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6441,7 +6441,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -6452,7 +6452,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6461,7 +6461,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -6472,9 +6472,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -6491,7 +6491,7 @@
       "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.x"
+        "source-map": "0.5.7"
       }
     },
     "cli": {
@@ -6501,7 +6501,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "^7.1.1"
+        "glob": "7.1.2"
       },
       "dependencies": {
         "glob": {
@@ -6510,12 +6510,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -6524,7 +6524,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6535,9 +6535,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -6564,9 +6564,9 @@
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^1.0.6",
-        "through2": "^2.0.1"
+        "inherits": "2.0.3",
+        "process-nextick-args": "1.0.7",
+        "through2": "2.0.3"
       }
     },
     "co": {
@@ -6582,7 +6582,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "q": "^1.1.2"
+        "q": "1.5.1"
       },
       "dependencies": {
         "q": {
@@ -6606,8 +6606,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -6616,7 +6616,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -6643,7 +6643,7 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "^4.5.0"
+        "lodash": "4.17.4"
       }
     },
     "combine-source-map": {
@@ -6652,10 +6652,10 @@
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
-        "convert-source-map": "~1.1.0",
-        "inline-source-map": "~0.6.0",
-        "lodash.memoize": "~3.0.3",
-        "source-map": "~0.5.3"
+        "convert-source-map": "1.1.3",
+        "inline-source-map": "0.6.2",
+        "lodash.memoize": "3.0.4",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "convert-source-map": {
@@ -6672,7 +6672,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -6708,9 +6708,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -6725,13 +6725,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -6740,7 +6740,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -6751,7 +6751,7 @@
       "integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -6775,7 +6775,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.0.6",
-        "parseurl": "~1.3.2",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
       }
     },
@@ -6791,7 +6791,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "console-control-strings": {
@@ -6813,7 +6813,7 @@
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
       "requires": {
-        "bluebird": "^3.1.1"
+        "bluebird": "3.5.1"
       }
     },
     "constants-browserify": {
@@ -6873,8 +6873,8 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-error-class": {
@@ -6883,7 +6883,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "create-hash": {
@@ -6892,10 +6892,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.10"
       }
     },
     "create-hmac": {
@@ -6904,12 +6904,12 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.10"
       }
     },
     "cross-spawn": {
@@ -6919,9 +6919,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -6931,8 +6931,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         }
       }
@@ -6958,7 +6958,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -6967,7 +6967,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.0"
           }
         }
       }
@@ -6978,17 +6978,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.14",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.3"
       }
     },
     "css-select": {
@@ -6998,10 +6998,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "^1.0.1"
+        "nth-check": "1.0.1"
       },
       "dependencies": {
         "domutils": {
@@ -7011,8 +7011,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
+            "dom-serializer": "0.1.0",
+            "domelementtype": "1.3.0"
           }
         }
       }
@@ -7031,8 +7031,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mdn-data": "^1.0.0",
-        "source-map": "^0.5.3"
+        "mdn-data": "1.1.0",
+        "source-map": "0.5.7"
       }
     },
     "css-url-regex": {
@@ -7066,8 +7066,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mdn-data": "^1.0.0",
-            "source-map": "^0.5.3"
+            "mdn-data": "1.1.0",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -7084,7 +7084,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "custom-event": {
@@ -7099,7 +7099,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -7161,15 +7161,15 @@
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
       "dev": true,
       "requires": {
-        "buffer-to-vinyl": "^1.0.0",
-        "concat-stream": "^1.4.6",
-        "decompress-tar": "^3.0.0",
-        "decompress-tarbz2": "^3.0.0",
-        "decompress-targz": "^3.0.0",
-        "decompress-unzip": "^3.0.0",
-        "stream-combiner2": "^1.1.1",
-        "vinyl-assign": "^1.0.1",
-        "vinyl-fs": "^2.2.0"
+        "buffer-to-vinyl": "1.1.0",
+        "concat-stream": "1.6.0",
+        "decompress-tar": "3.1.0",
+        "decompress-tarbz2": "3.1.0",
+        "decompress-targz": "3.1.0",
+        "decompress-unzip": "3.4.0",
+        "stream-combiner2": "1.1.1",
+        "vinyl-assign": "1.2.1",
+        "vinyl-fs": "2.4.4"
       },
       "dependencies": {
         "arr-diff": {
@@ -7178,7 +7178,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -7193,9 +7193,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "expand-brackets": {
@@ -7204,7 +7204,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -7213,7 +7213,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "glob": {
@@ -7222,11 +7222,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-stream": {
@@ -7235,14 +7235,14 @@
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "isarray": {
@@ -7257,10 +7257,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -7275,8 +7275,8 @@
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -7299,7 +7299,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "isarray": {
@@ -7314,7 +7314,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -7323,19 +7323,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "object-assign": {
@@ -7350,8 +7350,8 @@
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.3"
           }
         },
         "readable-stream": {
@@ -7360,13 +7360,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -7375,7 +7375,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -7384,7 +7384,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "unique-stream": {
@@ -7393,8 +7393,8 @@
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "vinyl": {
@@ -7403,8 +7403,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -7414,23 +7414,23 @@
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.5.3",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.3",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
           }
         }
       }
@@ -7441,12 +7441,12 @@
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
       "dev": true,
       "requires": {
-        "is-tar": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-tar": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -7467,10 +7467,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -7479,8 +7479,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -7489,8 +7489,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -7501,13 +7501,13 @@
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
       "dev": true,
       "requires": {
-        "is-bzip2": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "seek-bzip": "^1.0.3",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-bzip2": "1.0.0",
+        "object-assign": "2.1.1",
+        "seek-bzip": "1.0.5",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -7528,10 +7528,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -7540,8 +7540,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -7550,8 +7550,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -7562,12 +7562,12 @@
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
       "dev": true,
       "requires": {
-        "is-gzip": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-gzip": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -7588,10 +7588,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -7600,8 +7600,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -7610,8 +7610,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -7622,13 +7622,13 @@
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
       "dev": true,
       "requires": {
-        "is-zip": "^1.0.0",
-        "read-all-stream": "^3.0.0",
-        "stat-mode": "^0.2.0",
-        "strip-dirs": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0",
-        "yauzl": "^2.2.1"
+        "is-zip": "1.0.0",
+        "read-all-stream": "3.1.0",
+        "stat-mode": "0.2.2",
+        "strip-dirs": "1.1.1",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0",
+        "yauzl": "2.9.1"
       },
       "dependencies": {
         "vinyl": {
@@ -7637,8 +7637,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -7657,7 +7657,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.3"
       }
     },
     "define-properties": {
@@ -7666,8 +7666,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -7676,7 +7676,7 @@
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.0"
+        "is-descriptor": "1.0.2"
       }
     },
     "defined": {
@@ -7692,9 +7692,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ast-types": "0.x.x",
-        "escodegen": "1.x.x",
-        "esprima": "3.x.x"
+        "ast-types": "0.10.1",
+        "escodegen": "1.9.0",
+        "esprima": "3.1.3"
       },
       "dependencies": {
         "esprima": {
@@ -7736,10 +7736,10 @@
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "shasum": "^1.0.0",
-        "subarg": "^1.0.0",
-        "through2": "^2.0.0"
+        "JSONStream": "1.3.2",
+        "shasum": "1.0.2",
+        "subarg": "1.0.0",
+        "through2": "2.0.3"
       }
     },
     "des.js": {
@@ -7748,8 +7748,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "destroy": {
@@ -7770,8 +7770,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
+        "acorn": "5.3.0",
+        "defined": "1.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -7800,9 +7800,9 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "dom-serialize": {
@@ -7811,10 +7811,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "void-elements": "2.0.1"
       }
     },
     "dom-serializer": {
@@ -7823,8 +7823,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -7859,7 +7859,7 @@
       "integrity": "sha1-Wd+dzSJ+gIs2Wuc+H2aErD2Ub8I=",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -7868,7 +7868,7 @@
       "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "double-ended-queue": {
@@ -7884,21 +7884,21 @@
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "dev": true,
       "requires": {
-        "caw": "^1.0.1",
-        "concat-stream": "^1.4.7",
-        "each-async": "^1.0.0",
-        "filenamify": "^1.0.1",
-        "got": "^5.0.0",
-        "gulp-decompress": "^1.2.0",
-        "gulp-rename": "^1.2.0",
-        "is-url": "^1.2.0",
-        "object-assign": "^4.0.1",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.2",
-        "stream-combiner2": "^1.1.1",
-        "vinyl": "^1.0.0",
-        "vinyl-fs": "^2.2.0",
-        "ware": "^1.2.0"
+        "caw": "1.2.0",
+        "concat-stream": "1.6.0",
+        "each-async": "1.1.1",
+        "filenamify": "1.2.1",
+        "got": "5.7.1",
+        "gulp-decompress": "1.2.0",
+        "gulp-rename": "1.2.2",
+        "is-url": "1.2.2",
+        "object-assign": "4.1.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.3",
+        "stream-combiner2": "1.1.1",
+        "vinyl": "1.2.0",
+        "vinyl-fs": "2.4.4",
+        "ware": "1.3.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -7907,7 +7907,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -7922,9 +7922,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "duplexer2": {
@@ -7933,7 +7933,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.3"
           }
         },
         "expand-brackets": {
@@ -7942,7 +7942,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -7951,7 +7951,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "glob": {
@@ -7960,11 +7960,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-stream": {
@@ -7973,14 +7973,14 @@
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "isarray": {
@@ -7995,10 +7995,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -8013,8 +8013,8 @@
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -8025,21 +8025,21 @@
           "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
           "dev": true,
           "requires": {
-            "create-error-class": "^3.0.1",
-            "duplexer2": "^0.1.4",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "node-status-codes": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "parse-json": "^2.1.0",
-            "pinkie-promise": "^2.0.0",
-            "read-all-stream": "^3.0.0",
-            "readable-stream": "^2.0.5",
-            "timed-out": "^3.0.0",
-            "unzip-response": "^1.0.2",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer2": "0.1.4",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.0",
+            "node-status-codes": "1.0.0",
+            "object-assign": "4.1.1",
+            "parse-json": "2.2.0",
+            "pinkie-promise": "2.0.1",
+            "read-all-stream": "3.1.0",
+            "readable-stream": "2.3.3",
+            "timed-out": "3.1.3",
+            "unzip-response": "1.0.2",
+            "url-parse-lax": "1.0.0"
           }
         },
         "graceful-fs": {
@@ -8060,7 +8060,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "isarray": {
@@ -8075,7 +8075,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -8084,19 +8084,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "object-assign": {
@@ -8111,8 +8111,8 @@
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.3"
           }
         },
         "readable-stream": {
@@ -8121,13 +8121,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -8136,7 +8136,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -8145,7 +8145,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "timed-out": {
@@ -8160,8 +8160,8 @@
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "vinyl": {
@@ -8170,8 +8170,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -8181,23 +8181,23 @@
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.5.3",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.3",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
           }
         }
       }
@@ -8208,7 +8208,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       }
     },
     "duplexify": {
@@ -8217,10 +8217,10 @@
       "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "stream-shift": "1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -8229,7 +8229,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -8244,7 +8244,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "readable-stream": {
@@ -8253,13 +8253,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -8268,7 +8268,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -8279,8 +8279,8 @@
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
-        "onetime": "^1.0.0",
-        "set-immediate-shim": "^1.0.0"
+        "onetime": "1.1.0",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "easy-extender": {
@@ -8289,7 +8289,7 @@
       "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
       "dev": true,
       "requires": {
-        "lodash": "^3.10.1"
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -8306,7 +8306,7 @@
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
       "dev": true,
       "requires": {
-        "tfunk": "^3.0.1"
+        "tfunk": "3.1.0"
       }
     },
     "ecc-jsbn": {
@@ -8316,7 +8316,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "ee-first": {
@@ -8331,13 +8331,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "encodeurl": {
@@ -8352,7 +8352,7 @@
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
       "requires": {
-        "once": "~1.3.0"
+        "once": "1.3.3"
       }
     },
     "engine.io": {
@@ -8364,10 +8364,10 @@
         "accepts": "1.3.3",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~2.6.9",
-        "engine.io-parser": "~2.1.0",
-        "uws": "~0.14.4",
-        "ws": "~3.3.1"
+        "debug": "2.6.9",
+        "engine.io-parser": "2.1.2",
+        "uws": "0.14.5",
+        "ws": "3.3.3"
       }
     },
     "engine.io-client": {
@@ -8377,14 +8377,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~2.6.9",
-        "engine.io-parser": "~2.1.1",
+        "debug": "2.6.9",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       }
     },
@@ -8394,10 +8394,10 @@
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.2"
       }
     },
     "ent": {
@@ -8418,7 +8418,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -8427,11 +8427,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -8440,9 +8440,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es6-promise": {
@@ -8470,11 +8470,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.5.6"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "esprima": {
@@ -8524,8 +8524,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
       }
     },
     "exec-buffer": {
@@ -8535,11 +8535,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "execa": "^0.7.0",
-        "p-finally": "^1.0.0",
-        "pify": "^3.0.0",
-        "rimraf": "^2.5.4",
-        "tempfile": "^2.0.0"
+        "execa": "0.7.0",
+        "p-finally": "1.0.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2",
+        "tempfile": "2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -8549,12 +8549,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -8564,7 +8564,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "pify": {
@@ -8581,7 +8581,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         }
       }
@@ -8593,8 +8593,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async-each-series": "^1.1.0",
-        "object-assign": "^4.1.0"
+        "async-each-series": "1.1.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -8613,13 +8613,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "executable": {
@@ -8629,7 +8629,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "meow": "^3.1.0"
+        "meow": "3.7.0"
       }
     },
     "exit": {
@@ -8644,9 +8644,9 @@
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
-        "array-slice": "^0.2.3",
-        "array-unique": "^0.2.1",
-        "braces": "^0.1.2"
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
       },
       "dependencies": {
         "array-slice": {
@@ -8667,7 +8667,7 @@
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
-            "expand-range": "^0.1.0"
+            "expand-range": "0.1.1"
           }
         },
         "expand-range": {
@@ -8676,8 +8676,8 @@
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
           "dev": true,
           "requires": {
-            "is-number": "^0.1.1",
-            "repeat-string": "^0.2.2"
+            "is-number": "0.1.1",
+            "repeat-string": "0.2.2"
           }
         },
         "is-number": {
@@ -8700,13 +8700,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -8715,7 +8715,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -8724,7 +8724,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -8733,7 +8733,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -8744,7 +8744,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -8753,7 +8753,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -8764,9 +8764,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -8783,7 +8783,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       },
       "dependencies": {
         "fill-range": {
@@ -8792,11 +8792,11 @@
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^1.1.3",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "is-number": {
@@ -8805,7 +8805,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isarray": {
@@ -8829,7 +8829,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -8840,7 +8840,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "extend": {
@@ -8854,7 +8854,7 @@
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "is-extendable": "^0.1.0"
+        "is-extendable": "0.1.1"
       }
     },
     "extglob": {
@@ -8863,14 +8863,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
       }
     },
     "extract-zip": {
@@ -8891,9 +8891,9 @@
           "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~2.0.0",
-            "typedarray": "~0.0.5"
+            "inherits": "2.0.3",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
           }
         },
         "debug": {
@@ -8929,12 +8929,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "yauzl": {
@@ -8943,7 +8943,7 @@
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true,
           "requires": {
-            "fd-slicer": "~1.0.1"
+            "fd-slicer": "1.0.1"
           }
         }
       }
@@ -8960,9 +8960,9 @@
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -8990,7 +8990,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -9000,8 +9000,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -9049,9 +9049,9 @@
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "^1.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "1.0.0",
+        "strip-outer": "1.0.0",
+        "trim-repeated": "1.0.0"
       }
     },
     "fill-range": {
@@ -9060,10 +9060,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       }
     },
     "finalhandler": {
@@ -9073,12 +9073,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -9101,8 +9101,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "find-versions": {
@@ -9112,10 +9112,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "array-uniq": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "meow": "^3.5.0",
-        "semver-regex": "^1.0.0"
+        "array-uniq": "1.0.3",
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0",
+        "semver-regex": "1.0.0"
       }
     },
     "findup-sync": {
@@ -9124,10 +9124,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.5",
+        "resolve-dir": "1.0.1"
       }
     },
     "fined": {
@@ -9136,11 +9136,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "first-chunk-stream": {
@@ -9162,7 +9162,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "debug": "^2.2.0"
+        "debug": "2.6.9"
       }
     },
     "for-in": {
@@ -9177,7 +9177,7 @@
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -9198,9 +9198,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       },
       "dependencies": {
         "combined-stream": {
@@ -9209,7 +9209,7 @@
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         }
       }
@@ -9220,7 +9220,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -9235,7 +9235,7 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "^1.0.0"
+        "null-check": "1.0.0"
       }
     },
     "fs-extra": {
@@ -9244,11 +9244,11 @@
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "graceful-fs": {
@@ -9272,8 +9272,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.3.0",
-        "node-pre-gyp": "^0.6.39"
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -9288,8 +9288,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
@@ -9309,8 +9309,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
           }
         },
         "asn1": {
@@ -9354,7 +9354,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "block-stream": {
@@ -9362,7 +9362,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "boom": {
@@ -9370,7 +9370,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
@@ -9378,7 +9378,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^0.4.1",
+            "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
           }
         },
@@ -9409,7 +9409,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
@@ -9432,7 +9432,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "dashdash": {
@@ -9441,7 +9441,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -9490,7 +9490,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "extend": {
@@ -9516,9 +9516,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
           }
         },
         "fs.realpath": {
@@ -9531,10 +9531,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
           }
         },
         "fstream-ignore": {
@@ -9543,9 +9543,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
           }
         },
         "gauge": {
@@ -9554,14 +9554,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "getpass": {
@@ -9570,7 +9570,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -9586,12 +9586,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -9611,8 +9611,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "has-unicode": {
@@ -9626,10 +9626,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -9643,9 +9643,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
           }
         },
         "inflight": {
@@ -9653,8 +9653,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -9673,7 +9673,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
@@ -9699,7 +9699,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "jsbn": {
@@ -9720,7 +9720,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -9765,7 +9765,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "~1.27.0"
+            "mime-db": "1.27.0"
           }
         },
         "minimatch": {
@@ -9773,7 +9773,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
@@ -9801,17 +9801,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
+            "detect-libc": "1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
             "request": "2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
           }
         },
         "nopt": {
@@ -9820,8 +9820,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
@@ -9830,10 +9830,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -9858,7 +9858,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -9879,8 +9879,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -9917,10 +9917,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -9936,13 +9936,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
@@ -9951,28 +9951,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
           }
         },
         "rimraf": {
@@ -9980,7 +9980,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -10011,7 +10011,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "sshpk": {
@@ -10020,15 +10020,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jodid25519": "^1.0.0",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "assert-plus": {
@@ -10044,9 +10044,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -10054,7 +10054,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -10068,7 +10068,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -10082,9 +10082,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         },
         "tar-pack": {
@@ -10093,14 +10093,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
           }
         },
         "tough-cookie": {
@@ -10109,7 +10109,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
@@ -10118,7 +10118,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "tweetnacl": {
@@ -10159,7 +10159,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -10175,10 +10175,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "graceful-fs": {
@@ -10196,7 +10196,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "readable-stream": "1.1.x",
+        "readable-stream": "1.1.14",
         "xregexp": "2.0.0"
       }
     },
@@ -10205,8 +10205,8 @@
       "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-3.8.1.tgz",
       "integrity": "sha1-VACkgMMDG0pF/VOGZWs3aPaCebo=",
       "requires": {
-        "jquery": "2 - 3",
-        "moment": "^2.9.0"
+        "jquery": "2.2.4",
+        "moment": "2.20.1"
       }
     },
     "function-bind": {
@@ -10221,14 +10221,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
       },
       "dependencies": {
         "object-assign": {
@@ -10245,7 +10245,7 @@
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
-        "globule": "~0.1.0"
+        "globule": "0.1.0"
       }
     },
     "generate-function": {
@@ -10260,7 +10260,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "geometry-interfaces": {
@@ -10281,7 +10281,7 @@
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "dev": true,
       "requires": {
-        "rc": "^1.1.2"
+        "rc": "1.2.4"
       }
     },
     "get-stdin": {
@@ -10304,12 +10304,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "data-uri-to-buffer": "1",
-        "debug": "2",
-        "extend": "3",
-        "file-uri-to-path": "1",
-        "ftp": "~0.3.10",
-        "readable-stream": "2"
+        "data-uri-to-buffer": "1.2.0",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "file-uri-to-path": "1.0.0",
+        "ftp": "0.3.10",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -10326,13 +10326,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -10342,7 +10342,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -10359,7 +10359,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -10377,9 +10377,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "glob": {
@@ -10388,10 +10388,10 @@
       "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
       "dev": true,
       "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^2.0.1",
-        "once": "^1.3.0"
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "2.0.10",
+        "once": "1.3.3"
       }
     },
     "glob-base": {
@@ -10400,8 +10400,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -10410,7 +10410,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -10425,7 +10425,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -10436,8 +10436,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       }
     },
     "glob-stream": {
@@ -10446,12 +10446,12 @@
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
       "requires": {
-        "glob": "^4.3.1",
-        "glob2base": "^0.0.12",
-        "minimatch": "^2.0.1",
-        "ordered-read-streams": "^0.1.0",
-        "through2": "^0.6.1",
-        "unique-stream": "^1.0.0"
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -10460,10 +10460,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -10472,8 +10472,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -10484,7 +10484,7 @@
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "requires": {
-        "gaze": "^0.5.1"
+        "gaze": "0.5.2"
       }
     },
     "glob2base": {
@@ -10493,7 +10493,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "global-modules": {
@@ -10502,9 +10502,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.1",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -10513,11 +10513,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.1",
+        "which": "1.3.0"
       }
     },
     "globby": {
@@ -10526,11 +10526,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "glob": {
@@ -10539,12 +10539,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -10553,7 +10553,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "object-assign": {
@@ -10570,9 +10570,9 @@
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
-        "glob": "~3.1.21",
-        "lodash": "~1.0.1",
-        "minimatch": "~0.2.11"
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
       },
       "dependencies": {
         "glob": {
@@ -10581,9 +10581,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
           }
         },
         "graceful-fs": {
@@ -10610,8 +10610,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -10622,7 +10622,7 @@
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "govuk_frontend_toolkit": {
@@ -10636,7 +10636,7 @@
       "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
       "dev": true,
       "requires": {
-        "natives": "^1.1.0"
+        "natives": "1.1.1"
       }
     },
     "graceful-readlink": {
@@ -10651,19 +10651,19 @@
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.0.0",
-        "deprecated": "^0.0.1",
-        "gulp-util": "^3.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.1.0",
-        "minimist": "^1.1.0",
-        "orchestrator": "^0.3.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver": "^4.1.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.2",
-        "vinyl-fs": "^0.3.0"
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
       }
     },
     "gulp-angular-templates": {
@@ -10672,9 +10672,9 @@
       "integrity": "sha1-tgre2i51yGFO1oUvqQl80bB9fMw=",
       "dev": true,
       "requires": {
-        "cheerio": "^0.13.1",
-        "gulp-util": "~2.2.5",
-        "lodash": "~2.4.1"
+        "cheerio": "0.13.1",
+        "gulp-util": "2.2.20",
+        "lodash": "2.4.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10695,11 +10695,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "dateformat": {
@@ -10708,8 +10708,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "gulp-util": {
@@ -10718,14 +10718,14 @@
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
           "requires": {
-            "chalk": "^0.5.0",
-            "dateformat": "^1.0.7-1.2.3",
-            "lodash._reinterpolate": "^2.4.1",
-            "lodash.template": "^2.4.1",
-            "minimist": "^0.2.0",
-            "multipipe": "^0.1.0",
-            "through2": "^0.5.0",
-            "vinyl": "^0.2.1"
+            "chalk": "0.5.1",
+            "dateformat": "1.0.12",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.template": "2.4.1",
+            "minimist": "0.2.0",
+            "multipipe": "0.1.2",
+            "through2": "0.5.1",
+            "vinyl": "0.2.3"
           }
         },
         "has-ansi": {
@@ -10734,7 +10734,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "lodash": {
@@ -10755,9 +10755,9 @@
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "dev": true,
           "requires": {
-            "lodash._escapehtmlchar": "~2.4.1",
-            "lodash._reunescapedhtml": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._escapehtmlchar": "2.4.1",
+            "lodash._reunescapedhtml": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.keys": {
@@ -10766,9 +10766,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         },
         "lodash.template": {
@@ -10777,13 +10777,13 @@
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "~2.4.1",
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.defaults": "~2.4.1",
-            "lodash.escape": "~2.4.1",
-            "lodash.keys": "~2.4.1",
-            "lodash.templatesettings": "~2.4.1",
-            "lodash.values": "~2.4.1"
+            "lodash._escapestringchar": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.defaults": "2.4.1",
+            "lodash.escape": "2.4.1",
+            "lodash.keys": "2.4.1",
+            "lodash.templatesettings": "2.4.1",
+            "lodash.values": "2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -10792,8 +10792,8 @@
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.escape": "~2.4.1"
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.escape": "2.4.1"
           }
         },
         "minimist": {
@@ -10808,10 +10808,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "strip-ansi": {
@@ -10820,7 +10820,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -10835,8 +10835,8 @@
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~3.0.0"
+            "readable-stream": "1.0.34",
+            "xtend": "3.0.0"
           }
         },
         "vinyl": {
@@ -10845,7 +10845,7 @@
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "dev": true,
           "requires": {
-            "clone-stats": "~0.0.1"
+            "clone-stats": "0.0.1"
           }
         },
         "xtend": {
@@ -10874,9 +10874,9 @@
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "dev": true,
       "requires": {
-        "concat-with-sourcemaps": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.0"
+        "concat-with-sourcemaps": "1.0.5",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -10903,12 +10903,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.0.0",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -10919,7 +10919,7 @@
       "integrity": "sha1-mYDDzcr6m8TNMKuHEIesE1lVtVg=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -10934,13 +10934,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -10949,7 +10949,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -10960,7 +10960,7 @@
       "integrity": "sha1-7zc7YTSvMbD4xR9etV+qC9dU31I=",
       "dev": true,
       "requires": {
-        "consolidate": "~0.14.0",
+        "consolidate": "0.14.5",
         "map-stream": "0.0.4"
       }
     },
@@ -10970,10 +10970,10 @@
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
       "dev": true,
       "requires": {
-        "archive-type": "^3.0.0",
-        "decompress": "^3.0.0",
-        "gulp-util": "^3.0.1",
-        "readable-stream": "^2.0.2"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -10988,13 +10988,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11003,7 +11003,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -11014,15 +11014,15 @@
       "integrity": "sha512-3fveewgAwG+yukCTuPZWvMewo2cyAMB/2ymaAAcsxVx/58dYE8cflB43VlKmGcmICDFbNGXoiOYfvPTGZtM8bw==",
       "dev": true,
       "requires": {
-        "gulp-cond": "^1.0.0",
-        "gulp-spawn": "^0.4.0",
-        "gulp-svg2ttf": "^2.0.0",
-        "gulp-svgicons2svgfont": "^4.0.2",
-        "gulp-ttf2eot": "^1.1.1",
-        "gulp-ttf2woff": "^1.1.0",
-        "gulp-ttf2woff2": "^2.0.2",
-        "plexer": "^1.0.1",
-        "streamfilter": "^1.0.5"
+        "gulp-cond": "1.0.0",
+        "gulp-spawn": "0.4.0",
+        "gulp-svg2ttf": "2.0.1",
+        "gulp-svgicons2svgfont": "4.0.2",
+        "gulp-ttf2eot": "1.1.2",
+        "gulp-ttf2woff": "1.1.1",
+        "gulp-ttf2woff2": "2.0.2",
+        "plexer": "1.0.2",
+        "streamfilter": "1.0.7"
       }
     },
     "gulp-iconfont-css": {
@@ -11031,9 +11031,9 @@
       "integrity": "sha1-QMD16/yI9kCXzOLNrNc/i0DOlnM=",
       "dev": true,
       "requires": {
-        "consolidate": "^0.13.1",
-        "gulp-util": "^3.0.6",
-        "lodash": "^3.10.0"
+        "consolidate": "0.13.1",
+        "gulp-util": "3.0.8",
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "bluebird": {
@@ -11048,7 +11048,7 @@
           "integrity": "sha1-npUDVo60hQiJ2m7YeoUsjdLRP2Q=",
           "dev": true,
           "requires": {
-            "bluebird": "^2.9.26"
+            "bluebird": "2.11.0"
           }
         },
         "lodash": {
@@ -11065,8 +11065,8 @@
       "integrity": "sha1-XC6ioKRALgq0orzRLv2SlTRNePI=",
       "dev": true,
       "requires": {
-        "gulp-match": "^1.0.3",
-        "through2": "^2.0.1"
+        "gulp-match": "1.0.3",
+        "through2": "2.0.3"
       }
     },
     "gulp-imagemin": {
@@ -11075,17 +11075,17 @@
       "integrity": "sha512-6nWkrMNY5ub+34+DwlgQdWg21Z4DWAOARLpnyuZ773pGPJrfiyQrkOzdz9DgQSGBQjU1zuw6gd+9clLi6eicuw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.1.0",
-        "fancy-log": "^1.3.2",
-        "imagemin": "^5.3.1",
-        "imagemin-gifsicle": "^5.2.0",
-        "imagemin-jpegtran": "^5.0.2",
-        "imagemin-optipng": "^5.2.1",
-        "imagemin-svgo": "^6.0.0",
-        "plugin-error": "^0.1.2",
-        "plur": "^2.1.2",
-        "pretty-bytes": "^4.0.2",
-        "through2-concurrent": "^1.1.1"
+        "chalk": "2.3.0",
+        "fancy-log": "1.3.2",
+        "imagemin": "5.3.1",
+        "imagemin-gifsicle": "5.2.0",
+        "imagemin-jpegtran": "5.0.2",
+        "imagemin-optipng": "5.2.1",
+        "imagemin-svgo": "6.0.0",
+        "plugin-error": "0.1.2",
+        "plur": "2.1.2",
+        "pretty-bytes": "4.0.2",
+        "through2-concurrent": "1.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11094,7 +11094,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -11103,9 +11103,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           }
         },
         "supports-color": {
@@ -11114,7 +11114,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -11125,11 +11125,11 @@
       "integrity": "sha512-sP3NK8Y/1e58O0PH9t6s7DAr/lKDSUbIY207oWSeufM6/VclB7jJrIBcPCsyhrFTCDUl9DauePbt6VqP2vPM5w==",
       "dev": true,
       "requires": {
-        "lodash": "^4.12.0",
-        "minimatch": "^3.0.3",
-        "plugin-error": "^0.1.2",
-        "rcloader": "^0.2.2",
-        "through2": "^2.0.0"
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "plugin-error": "0.1.2",
+        "rcloader": "0.2.2",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "minimatch": {
@@ -11138,7 +11138,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -11149,7 +11149,7 @@
       "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.3"
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -11158,7 +11158,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -11169,12 +11169,12 @@
       "integrity": "sha512-wjazOa5qE83akCih+lK2a0LFvkLbIMeblxr54ofmc3WKJ3Ipx/BM98ZCtCDfQW/008EVUSRqwfEjFKEEGI0QbA==",
       "dev": true,
       "requires": {
-        "bufferstreams": "^1.1.0",
-        "merge": "^1.2.0",
-        "ng-annotate": "^1.2.1",
-        "plugin-error": "^0.1.2",
-        "through2": "^2.0.1",
-        "vinyl-sourcemaps-apply": "^0.2.1"
+        "bufferstreams": "1.1.3",
+        "merge": "1.2.0",
+        "ng-annotate": "1.2.2",
+        "plugin-error": "0.1.2",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "gulp-ng-constant": {
@@ -11183,12 +11183,12 @@
       "integrity": "sha512-Ig0nnyJEeyd9RqQwNkE1uUeldo6UcZ+HMs6qNYvztcTbj0do2GC99sK10pqThMLpiQ51ENwVlR5t4PKuVAd0fQ==",
       "dev": true,
       "requires": {
-        "js-yaml": "^3.2.7",
-        "lodash": "^4.14.1",
-        "plugin-error": "^0.1.2",
-        "replace-ext": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^2.1.0"
+        "js-yaml": "3.10.0",
+        "lodash": "4.17.4",
+        "plugin-error": "0.1.2",
+        "replace-ext": "1.0.0",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -11215,8 +11215,8 @@
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
           }
         },
         "replace-ext": {
@@ -11231,12 +11231,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.0.0",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -11253,8 +11253,8 @@
       "integrity": "sha512-36X2sfj2d++avb6TUpL9SQIqGR8Wl/NNBVw74ZbXZJ/MGWAmz6aPe/msuyVyUSZPn1RYlctSLV9W5uzPTMk+kw==",
       "dev": true,
       "requires": {
-        "rimraf": "^2.6.2",
-        "through2": "^2.0.3"
+        "rimraf": "2.6.2",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "glob": {
@@ -11263,12 +11263,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -11277,7 +11277,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "rimraf": {
@@ -11286,7 +11286,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         }
       }
@@ -11297,14 +11297,14 @@
       "integrity": "sha512-OMQEgWNggpog8Tc5v1MuI6eo+5iiPkVeLL76iBhDoEEScLUPfZlpvzmgTnLkpcqdrNodZxpz5qcv6mS2rulk3g==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "lodash.clonedeep": "^4.3.2",
-        "node-sass": "^4.8.3",
-        "plugin-error": "^1.0.1",
-        "replace-ext": "^1.0.0",
-        "strip-ansi": "^4.0.0",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "chalk": "2.4.1",
+        "lodash.clonedeep": "4.5.0",
+        "node-sass": "4.9.3",
+        "plugin-error": "1.0.1",
+        "replace-ext": "1.0.0",
+        "strip-ansi": "4.0.0",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11319,7 +11319,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -11328,9 +11328,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "extend-shallow": {
@@ -11339,8 +11339,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "has-flag": {
@@ -11355,7 +11355,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         },
         "plugin-error": {
@@ -11364,10 +11364,10 @@
           "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "dev": true,
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "arr-diff": "^4.0.0",
-            "arr-union": "^3.1.0",
-            "extend-shallow": "^3.0.2"
+            "ansi-colors": "1.1.0",
+            "arr-diff": "4.0.0",
+            "arr-union": "3.1.0",
+            "extend-shallow": "3.0.2"
           }
         },
         "replace-ext": {
@@ -11382,7 +11382,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -11391,7 +11391,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11402,11 +11402,11 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -11421,7 +11421,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "vinyl": {
@@ -11430,8 +11430,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -11443,7 +11443,7 @@
       "integrity": "sha1-m1URtSP088hBRauKC+Sdc1r+aqg=",
       "dev": true,
       "requires": {
-        "gulp-util": "~2.2.14",
+        "gulp-util": "2.2.20",
         "plexer": "0.0.1"
       },
       "dependencies": {
@@ -11465,11 +11465,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "dateformat": {
@@ -11478,8 +11478,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "gulp-util": {
@@ -11488,14 +11488,14 @@
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
           "requires": {
-            "chalk": "^0.5.0",
-            "dateformat": "^1.0.7-1.2.3",
-            "lodash._reinterpolate": "^2.4.1",
-            "lodash.template": "^2.4.1",
-            "minimist": "^0.2.0",
-            "multipipe": "^0.1.0",
-            "through2": "^0.5.0",
-            "vinyl": "^0.2.1"
+            "chalk": "0.5.1",
+            "dateformat": "1.0.12",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.template": "2.4.1",
+            "minimist": "0.2.0",
+            "multipipe": "0.1.2",
+            "through2": "0.5.1",
+            "vinyl": "0.2.3"
           }
         },
         "has-ansi": {
@@ -11504,7 +11504,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "lodash._reinterpolate": {
@@ -11519,9 +11519,9 @@
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "dev": true,
           "requires": {
-            "lodash._escapehtmlchar": "~2.4.1",
-            "lodash._reunescapedhtml": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._escapehtmlchar": "2.4.1",
+            "lodash._reunescapedhtml": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.keys": {
@@ -11530,9 +11530,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         },
         "lodash.template": {
@@ -11541,13 +11541,13 @@
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "~2.4.1",
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.defaults": "~2.4.1",
-            "lodash.escape": "~2.4.1",
-            "lodash.keys": "~2.4.1",
-            "lodash.templatesettings": "~2.4.1",
-            "lodash.values": "~2.4.1"
+            "lodash._escapestringchar": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.defaults": "2.4.1",
+            "lodash.escape": "2.4.1",
+            "lodash.keys": "2.4.1",
+            "lodash.templatesettings": "2.4.1",
+            "lodash.values": "2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -11556,8 +11556,8 @@
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.escape": "~2.4.1"
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.escape": "2.4.1"
           }
         },
         "minimist": {
@@ -11578,10 +11578,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "strip-ansi": {
@@ -11590,7 +11590,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -11605,8 +11605,8 @@
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~3.0.0"
+            "readable-stream": "1.0.34",
+            "xtend": "3.0.0"
           }
         },
         "vinyl": {
@@ -11615,7 +11615,7 @@
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "dev": true,
           "requires": {
-            "clone-stats": "~0.0.1"
+            "clone-stats": "0.0.1"
           }
         },
         "xtend": {
@@ -11632,10 +11632,10 @@
       "integrity": "sha1-EdaLu+J7ifR2V7TY8pzzOFTX5ow=",
       "dev": true,
       "requires": {
-        "bufferstreams": "^1.1.0",
-        "gulp-util": "^3.0.7",
-        "readable-stream": "^2.0.4",
-        "svg2ttf": "^4.1.0"
+        "bufferstreams": "1.1.3",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.3",
+        "svg2ttf": "4.1.0"
       },
       "dependencies": {
         "isarray": {
@@ -11650,13 +11650,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11665,7 +11665,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -11676,10 +11676,10 @@
       "integrity": "sha512-iU6GTtebppusN+wIk2KgZm/TZQCXhaiwW3CJkcqZ0jT3lUNXUz3b9BWhiGhpBhknolTtaUv09410UGi9CZNNng==",
       "dev": true,
       "requires": {
-        "gulp-util": "~3.0.6",
+        "gulp-util": "3.0.8",
         "plexer": "1.0.1",
-        "readable-stream": "^2.0.2",
-        "svgicons2svgfont": "^7.0.2"
+        "readable-stream": "2.3.3",
+        "svgicons2svgfont": "7.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -11694,8 +11694,8 @@
           "integrity": "sha1-qAG2Ur+BRXOXlepNO/CvlGwwwN0=",
           "dev": true,
           "requires": {
-            "isstream": "^0.1.2",
-            "readable-stream": "^2.0.2"
+            "isstream": "0.1.2",
+            "readable-stream": "2.3.3"
           }
         },
         "readable-stream": {
@@ -11704,13 +11704,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11719,7 +11719,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -11730,10 +11730,10 @@
       "integrity": "sha1-Z1Fv4lO67Ls5ELQXoI3LUeNKyww=",
       "dev": true,
       "requires": {
-        "bufferstreams": "^1.1.0",
-        "gulp-util": "^3.0.7",
-        "readable-stream": "^2.0.4",
-        "ttf2eot": "^2.0.0"
+        "bufferstreams": "1.1.3",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.3",
+        "ttf2eot": "2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -11748,13 +11748,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11763,7 +11763,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -11774,10 +11774,10 @@
       "integrity": "sha1-4iym5xvZrRBXUWRPixx+O+Owhqw=",
       "dev": true,
       "requires": {
-        "bufferstreams": "^1.0.2",
-        "gulp-util": "^3.0.6",
-        "readable-stream": "^2.0.1",
-        "ttf2woff": "^2.0.1"
+        "bufferstreams": "1.1.3",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.3",
+        "ttf2woff": "2.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -11792,13 +11792,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11807,7 +11807,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -11818,10 +11818,10 @@
       "integrity": "sha1-8QGxUg8jaqZ2fsRb9HVByxWe6zI=",
       "dev": true,
       "requires": {
-        "bufferstreams": "^1.1.0",
-        "gulp-util": "^3.0.7",
-        "readable-stream": "^2.0.4",
-        "ttf2woff2": "^2.0.3"
+        "bufferstreams": "1.1.3",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.3",
+        "ttf2woff2": "2.0.3"
       },
       "dependencies": {
         "isarray": {
@@ -11836,13 +11836,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11851,7 +11851,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -11862,13 +11862,13 @@
       "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co=",
       "dev": true,
       "requires": {
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash": "^4.13.1",
-        "make-error-cause": "^1.1.1",
-        "through2": "^2.0.0",
-        "uglify-js": "^3.0.5",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash": "4.17.4",
+        "make-error-cause": "1.2.2",
+        "through2": "2.0.3",
+        "uglify-js": "3.3.9",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "source-map": {
@@ -11883,8 +11883,8 @@
           "integrity": "sha512-J2t8B5tj9JdPTW4+sNZXmiIWHzTvcoITkaqzTiilu/biZF/9crqf/Fi7k5hqbOmVRh9/hVNxAxBYIMF7N6SqMQ==",
           "dev": true,
           "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
+            "commander": "2.13.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -11895,24 +11895,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "object-assign": {
@@ -11929,7 +11929,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "har-schema": {
@@ -11944,10 +11944,10 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "commander": "^2.9.0",
-        "is-my-json-valid": "^2.12.4",
-        "pinkie-promise": "^2.0.0"
+        "chalk": "1.1.3",
+        "commander": "2.13.0",
+        "is-my-json-valid": "2.17.1",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "commander": {
@@ -11964,7 +11964,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -11973,7 +11973,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -12008,7 +12008,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "has-own-property-x": {
@@ -12018,9 +12018,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "to-object-x": "^1.5.0",
-        "to-property-key-x": "^2.0.2"
+        "cached-constructors-x": "1.0.0",
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
       }
     },
     "has-symbol-support-x": {
@@ -12035,7 +12035,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.1"
       }
     },
     "has-unicode": {
@@ -12050,9 +12050,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -12061,8 +12061,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -12071,7 +12071,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -12082,7 +12082,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "hash.js": {
@@ -12091,8 +12091,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "hasha": {
@@ -12101,8 +12101,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "hipchat-notifier": {
@@ -12112,8 +12112,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "^4.0.0",
-        "request": "^2.0.0"
+        "lodash": "4.17.4",
+        "request": "2.83.0"
       }
     },
     "hmac-drbg": {
@@ -12122,9 +12122,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -12139,7 +12139,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -12167,10 +12167,10 @@
       "integrity": "sha1-oc1l9YI60oXhnWOwha1yLQpR6uc=",
       "dev": true,
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.2",
-        "domutils": "1.3",
-        "readable-stream": "1.1"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.2.1",
+        "domutils": "1.3.0",
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "domutils": {
@@ -12179,7 +12179,7 @@
           "integrity": "sha1-mtTVm1r2ymhMYv5tdo7xcOcN8ZI=",
           "dev": true,
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         }
       }
@@ -12193,7 +12193,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": ">= 1.3.1 < 2"
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "depd": {
@@ -12210,8 +12210,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "1.x.x"
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-agent": {
@@ -12220,9 +12220,9 @@
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
       }
     },
     "http-signature": {
@@ -12231,9 +12231,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
       }
     },
     "httpntlm": {
@@ -12242,8 +12242,8 @@
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
       "requires": {
-        "httpreq": ">=0.4.22",
-        "underscore": "~1.7.0"
+        "httpreq": "0.4.24",
+        "underscore": "1.7.0"
       },
       "dependencies": {
         "underscore": {
@@ -12272,9 +12272,9 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
       }
     },
     "iconv-lite": {
@@ -12295,12 +12295,12 @@
       "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
       "dev": true,
       "requires": {
-        "file-type": "^4.1.0",
-        "globby": "^6.1.0",
-        "make-dir": "^1.0.0",
-        "p-pipe": "^1.1.0",
-        "pify": "^2.3.0",
-        "replace-ext": "^1.0.0"
+        "file-type": "4.4.0",
+        "globby": "6.1.0",
+        "make-dir": "1.1.0",
+        "p-pipe": "1.2.0",
+        "pify": "2.3.0",
+        "replace-ext": "1.0.0"
       },
       "dependencies": {
         "replace-ext": {
@@ -12318,9 +12318,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "gifsicle": "^3.0.0",
-        "is-gif": "^1.0.0"
+        "exec-buffer": "3.2.0",
+        "gifsicle": "3.0.4",
+        "is-gif": "1.0.0"
       }
     },
     "imagemin-jpegtran": {
@@ -12330,9 +12330,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "is-jpg": "^1.0.0",
-        "jpegtran-bin": "^3.0.0"
+        "exec-buffer": "3.2.0",
+        "is-jpg": "1.0.0",
+        "jpegtran-bin": "3.2.0"
       }
     },
     "imagemin-optipng": {
@@ -12342,9 +12342,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "is-png": "^1.0.0",
-        "optipng-bin": "^3.0.0"
+        "exec-buffer": "3.2.0",
+        "is-png": "1.1.0",
+        "optipng-bin": "3.1.4"
       }
     },
     "imagemin-svgo": {
@@ -12354,9 +12354,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "buffer-from": "^0.1.1",
-        "is-svg": "^2.0.0",
-        "svgo": "^1.0.0"
+        "buffer-from": "0.1.1",
+        "is-svg": "2.1.0",
+        "svgo": "1.0.3"
       }
     },
     "immutable": {
@@ -12377,7 +12377,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexof": {
@@ -12405,8 +12405,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.3.3",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -12427,7 +12427,7 @@
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
-        "source-map": "~0.5.3"
+        "source-map": "0.5.7"
       }
     },
     "insert-module-globals": {
@@ -12436,14 +12436,14 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "combine-source-map": "~0.7.1",
-        "concat-stream": "~1.5.1",
-        "is-buffer": "^1.1.0",
-        "lexical-scope": "^1.2.0",
-        "process": "~0.11.0",
-        "through2": "^2.0.0",
-        "xtend": "^4.0.0"
+        "JSONStream": "1.3.2",
+        "combine-source-map": "0.7.2",
+        "concat-stream": "1.5.2",
+        "is-buffer": "1.1.6",
+        "lexical-scope": "1.2.0",
+        "process": "0.11.10",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "combine-source-map": {
@@ -12452,10 +12452,10 @@
           "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
           "dev": true,
           "requires": {
-            "convert-source-map": "~1.1.0",
-            "inline-source-map": "~0.6.0",
-            "lodash.memoize": "~3.0.3",
-            "source-map": "~0.5.3"
+            "convert-source-map": "1.1.3",
+            "inline-source-map": "0.6.2",
+            "lodash.memoize": "3.0.4",
+            "source-map": "0.5.7"
           }
         },
         "concat-stream": {
@@ -12464,9 +12464,9 @@
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~2.0.0",
-            "typedarray": "~0.0.5"
+            "inherits": "2.0.3",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
           }
         },
         "convert-source-map": {
@@ -12487,12 +12487,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -12535,8 +12535,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.1"
       }
     },
     "is-accessor-descriptor": {
@@ -12545,7 +12545,7 @@
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       }
     },
     "is-array-buffer-x": {
@@ -12555,11 +12555,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "attempt-x": "^1.1.0",
-        "has-to-string-tag-x": "^1.4.1",
-        "is-object-like-x": "^1.5.1",
-        "object-get-own-property-descriptor-x": "^3.2.0",
-        "to-string-tag-x": "^1.4.1"
+        "attempt-x": "1.1.1",
+        "has-to-string-tag-x": "1.4.1",
+        "is-object-like-x": "1.6.0",
+        "object-get-own-property-descriptor-x": "3.2.0",
+        "to-string-tag-x": "1.4.2"
       }
     },
     "is-arrayish": {
@@ -12574,7 +12574,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -12589,7 +12589,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-bzip2": {
@@ -12610,7 +12610,7 @@
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       }
     },
     "is-date-object": {
@@ -12625,9 +12625,9 @@
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
       }
     },
     "is-dotfile": {
@@ -12642,7 +12642,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -12663,7 +12663,7 @@
       "integrity": "sha512-XWNZC4A+3FX1ECoMjspuEFgSdio82IWjqY/suE0gZ10QA7nzHd/KraRq7Tc5VEHtFRgTRyTdY6W+ykPrDnyoAQ==",
       "dev": true,
       "requires": {
-        "to-boolean-x": "^1.0.1"
+        "to-boolean-x": "1.0.1"
       }
     },
     "is-finite": {
@@ -12672,7 +12672,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-finite-x": {
@@ -12682,8 +12682,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "infinity-x": "^1.0.0",
-        "is-nan-x": "^1.0.1"
+        "infinity-x": "1.0.0",
+        "is-nan-x": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -12692,7 +12692,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-function-x": {
@@ -12701,14 +12701,14 @@
       "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
       "dev": true,
       "requires": {
-        "attempt-x": "^1.1.1",
-        "has-to-string-tag-x": "^1.4.1",
-        "is-falsey-x": "^1.0.1",
-        "is-primitive": "^2.0.0",
-        "normalize-space-x": "^3.0.0",
-        "replace-comments-x": "^2.0.0",
-        "to-boolean-x": "^1.0.1",
-        "to-string-tag-x": "^1.4.2"
+        "attempt-x": "1.1.1",
+        "has-to-string-tag-x": "1.4.1",
+        "is-falsey-x": "1.0.1",
+        "is-primitive": "2.0.0",
+        "normalize-space-x": "3.0.0",
+        "replace-comments-x": "2.0.0",
+        "to-boolean-x": "1.0.1",
+        "to-string-tag-x": "1.4.2"
       }
     },
     "is-gif": {
@@ -12724,7 +12724,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-gzip": {
@@ -12740,11 +12740,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "math-clamp-x": "^1.2.0",
-        "max-safe-integer": "^1.0.1",
-        "to-integer-x": "^3.0.0",
-        "to-number-x": "^2.0.0",
-        "to-string-symbols-supported-x": "^1.0.0"
+        "math-clamp-x": "1.2.0",
+        "max-safe-integer": "1.0.1",
+        "to-integer-x": "3.0.0",
+        "to-number-x": "2.0.0",
+        "to-string-symbols-supported-x": "1.0.0"
       }
     },
     "is-jpg": {
@@ -12760,10 +12760,10 @@
       "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-nan-x": {
@@ -12784,8 +12784,8 @@
       "integrity": "sha512-cfTKWI5iSR04SSCzzugTH5tS2rYG7kwI8yl/AqWkyuxZ7k55cbA47Y7Lezdg1N9aaELd+UxLg628bdQeNQ6BUw==",
       "dev": true,
       "requires": {
-        "lodash.isnull": "^3.0.0",
-        "validate.io-undefined": "^1.0.3"
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
       }
     },
     "is-number": {
@@ -12794,7 +12794,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -12803,7 +12803,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -12814,7 +12814,7 @@
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "dev": true,
       "requires": {
-        "lodash.isfinite": "^3.3.2"
+        "lodash.isfinite": "3.3.2"
       }
     },
     "is-obj": {
@@ -12830,8 +12830,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-function-x": "^3.3.0",
-        "is-primitive": "^2.0.0"
+        "is-function-x": "3.3.0",
+        "is-primitive": "2.0.0"
       }
     },
     "is-odd": {
@@ -12840,7 +12840,7 @@
       "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0"
+        "is-number": "3.0.0"
       }
     },
     "is-plain-object": {
@@ -12849,7 +12849,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-png": {
@@ -12889,7 +12889,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-relative": {
@@ -12898,7 +12898,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-retry-allowed": {
@@ -12927,7 +12927,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.1"
       }
     },
     "is-symbol": {
@@ -12954,7 +12954,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-url": {
@@ -13023,8 +13023,8 @@
       "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.6",
-        "jasmine-core": "~3.2.0"
+        "glob": "7.1.2",
+        "jasmine-core": "3.2.1"
       },
       "dependencies": {
         "glob": {
@@ -13033,12 +13033,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -13047,7 +13047,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -13064,8 +13064,8 @@
       "integrity": "sha1-64y3NZZYVyqH7vSqCIo2MDbzeSo=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1",
-        "xmldom": "^0.1.22"
+        "mkdirp": "0.5.1",
+        "xmldom": "0.1.27"
       }
     },
     "jasmine-spec-reporter": {
@@ -13084,9 +13084,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "jquery": {
@@ -13113,14 +13113,14 @@
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
-        "cli": "~1.0.0",
-        "console-browserify": "1.1.x",
-        "exit": "0.1.x",
-        "htmlparser2": "3.8.x",
-        "lodash": "3.7.x",
-        "minimatch": "~3.0.2",
-        "shelljs": "0.3.x",
-        "strip-json-comments": "1.0.x"
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
       },
       "dependencies": {
         "domhandler": {
@@ -13129,7 +13129,7 @@
           "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
           "dev": true,
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "domutils": {
@@ -13138,8 +13138,8 @@
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
+            "dom-serializer": "0.1.0",
+            "domelementtype": "1.3.0"
           }
         },
         "entities": {
@@ -13154,11 +13154,11 @@
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "dev": true,
           "requires": {
-            "domelementtype": "1",
-            "domhandler": "2.3",
-            "domutils": "1.5",
-            "entities": "1.0",
-            "readable-stream": "1.1"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.3.0",
+            "domutils": "1.5.1",
+            "entities": "1.0.0",
+            "readable-stream": "1.1.14"
           }
         },
         "lodash": {
@@ -13173,7 +13173,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "strip-json-comments": {
@@ -13190,12 +13190,12 @@
       "integrity": "sha1-JCCCosA1rgP9gQROBXDMQgjPbmE=",
       "dev": true,
       "requires": {
-        "beeper": "^1.1.0",
-        "chalk": "^1.0.0",
-        "log-symbols": "^1.0.0",
-        "plur": "^2.1.0",
-        "string-length": "^1.0.0",
-        "text-table": "^0.2.0"
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "plur": "2.1.2",
+        "string-length": "1.0.1",
+        "text-table": "0.2.0"
       }
     },
     "json-schema": {
@@ -13216,7 +13216,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -13231,7 +13231,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "graceful-fs": {
@@ -13287,34 +13287,34 @@
       "integrity": "sha512-K9Kjp8CldLyL9ANSUctDyxC7zH3hpqXj/K09qVf06K3T/kXaHtFZ5tQciK7OzQu68FLvI89Na510kqQ2LCbpIw==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.3.0",
-        "body-parser": "^1.16.1",
-        "browserify": "^14.5.0",
-        "chokidar": "^1.4.1",
-        "colors": "^1.1.0",
-        "combine-lists": "^1.0.0",
-        "connect": "^3.6.0",
-        "core-js": "^2.2.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.0",
-        "expand-braces": "^0.1.1",
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "http-proxy": "^1.13.0",
-        "isbinaryfile": "^3.0.0",
-        "lodash": "^4.17.4",
-        "log4js": "^2.3.9",
-        "mime": "^1.3.4",
-        "minimatch": "^3.0.2",
-        "optimist": "^0.6.1",
-        "qjobs": "^1.1.4",
-        "range-parser": "^1.2.0",
-        "rimraf": "^2.6.0",
-        "safe-buffer": "^5.0.1",
+        "bluebird": "3.5.1",
+        "body-parser": "1.18.2",
+        "browserify": "14.5.0",
+        "chokidar": "1.7.0",
+        "colors": "1.1.2",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.5",
+        "core-js": "2.5.3",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "http-proxy": "1.16.2",
+        "isbinaryfile": "3.0.2",
+        "lodash": "4.17.4",
+        "log4js": "2.5.2",
+        "mime": "1.6.0",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.1.5",
+        "range-parser": "1.2.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.1",
         "socket.io": "2.0.4",
-        "source-map": "^0.6.1",
+        "source-map": "0.6.1",
         "tmp": "0.0.33",
-        "useragent": "^2.1.12"
+        "useragent": "2.2.1"
       },
       "dependencies": {
         "glob": {
@@ -13323,12 +13323,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -13343,7 +13343,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "rimraf": {
@@ -13352,7 +13352,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "source-map": {
@@ -13369,8 +13369,8 @@
       "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
-        "fs-access": "^1.0.0",
-        "which": "^1.2.1"
+        "fs-access": "1.0.1",
+        "which": "1.3.0"
       }
     },
     "karma-firefox-launcher": {
@@ -13391,7 +13391,7 @@
       "integrity": "sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=",
       "dev": true,
       "requires": {
-        "path-is-absolute": "^1.0.0",
+        "path-is-absolute": "1.0.1",
         "xmlbuilder": "8.2.2"
       }
     },
@@ -13401,8 +13401,8 @@
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "^4.0.1",
-        "phantomjs-prebuilt": "^2.1.7"
+        "lodash": "4.17.4",
+        "phantomjs-prebuilt": "2.1.16"
       },
       "dependencies": {
         "extract-zip": {
@@ -13423,9 +13423,9 @@
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1"
           }
         },
         "graceful-fs": {
@@ -13455,15 +13455,15 @@
           "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
           "dev": true,
           "requires": {
-            "es6-promise": "^4.0.3",
-            "extract-zip": "^1.6.5",
-            "fs-extra": "^1.0.0",
-            "hasha": "^2.2.0",
-            "kew": "^0.7.0",
-            "progress": "^1.1.8",
-            "request": "^2.81.0",
-            "request-progress": "^2.0.1",
-            "which": "^1.2.10"
+            "es6-promise": "4.2.4",
+            "extract-zip": "1.6.6",
+            "fs-extra": "1.0.0",
+            "hasha": "2.2.0",
+            "kew": "0.7.0",
+            "progress": "1.1.8",
+            "request": "2.83.0",
+            "request-progress": "2.0.1",
+            "which": "1.3.0"
           }
         },
         "request-progress": {
@@ -13472,7 +13472,7 @@
           "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
           "dev": true,
           "requires": {
-            "throttleit": "^1.0.0"
+            "throttleit": "1.0.0"
           }
         },
         "throttleit": {
@@ -13487,7 +13487,7 @@
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true,
           "requires": {
-            "fd-slicer": "~1.0.1"
+            "fd-slicer": "1.0.1"
           }
         }
       }
@@ -13510,7 +13510,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "graceful-fs": {
@@ -13528,9 +13528,9 @@
       "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "isarray": "~0.0.1",
-        "stream-splicer": "^2.0.0"
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "stream-splicer": "2.0.0"
       }
     },
     "lazy-cache": {
@@ -13539,7 +13539,7 @@
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "dev": true,
       "requires": {
-        "set-getter": "^0.1.0"
+        "set-getter": "0.1.0"
       }
     },
     "lazy-req": {
@@ -13555,7 +13555,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -13570,13 +13570,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -13585,7 +13585,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -13596,7 +13596,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "levn": {
@@ -13606,8 +13606,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lexical-scope": {
@@ -13616,7 +13616,7 @@
       "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
       "dev": true,
       "requires": {
-        "astw": "^2.0.0"
+        "astw": "2.2.0"
       }
     },
     "libbase64": {
@@ -13656,14 +13656,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.5.0"
       },
       "dependencies": {
         "extend": {
@@ -13686,11 +13686,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -13705,7 +13705,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -13728,8 +13728,8 @@
           "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
           "dev": true,
           "requires": {
-            "follow-redirects": "^1.2.5",
-            "is-buffer": "^1.1.5"
+            "follow-redirects": "1.4.1",
+            "is-buffer": "1.1.6"
           }
         },
         "camelcase": {
@@ -13753,7 +13753,7 @@
           "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
           "dev": true,
           "requires": {
-            "debug": "^3.1.0"
+            "debug": "3.1.0"
           },
           "dependencies": {
             "debug": {
@@ -13773,19 +13773,19 @@
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.2.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           }
         }
       }
@@ -13819,7 +13819,7 @@
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -13882,8 +13882,8 @@
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -13892,9 +13892,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -13911,7 +13911,7 @@
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.assign": {
@@ -13932,8 +13932,8 @@
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._objecttypes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -13942,9 +13942,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -13955,7 +13955,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.isarguments": {
@@ -13994,7 +13994,7 @@
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.keys": {
@@ -14003,9 +14003,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.memoize": {
@@ -14032,15 +14032,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -14049,8 +14049,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "lodash.values": {
@@ -14059,7 +14059,7 @@
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
       "requires": {
-        "lodash.keys": "~2.4.1"
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -14068,9 +14068,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -14081,7 +14081,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "log4js": {
@@ -14090,19 +14090,19 @@
       "integrity": "sha512-MmZhzQCfCV5+nQgOqy34V9EV3k+Z/rPCdxyq+25EePKpwdUQxCb19BTmL5iX3iOCSAV/tWh7KVYqchwrx3+S2Q==",
       "dev": true,
       "requires": {
-        "amqplib": "^0.5.2",
-        "axios": "^0.15.3",
-        "circular-json": "^0.5.1",
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "hipchat-notifier": "^1.1.0",
-        "loggly": "^1.1.0",
-        "mailgun-js": "^0.7.0",
-        "nodemailer": "^2.5.0",
-        "redis": "^2.7.1",
-        "semver": "^5.3.0",
-        "slack-node": "~0.2.0",
-        "streamroller": "^0.7.0"
+        "amqplib": "0.5.2",
+        "axios": "0.15.3",
+        "circular-json": "0.5.1",
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "hipchat-notifier": "1.1.0",
+        "loggly": "1.1.1",
+        "mailgun-js": "0.7.15",
+        "nodemailer": "2.7.2",
+        "redis": "2.8.0",
+        "semver": "5.5.0",
+        "slack-node": "0.2.0",
+        "streamroller": "0.7.0"
       },
       "dependencies": {
         "debug": {
@@ -14129,8 +14129,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "figures": "^1.3.5",
-        "squeak": "^1.0.0"
+        "figures": "1.7.0",
+        "squeak": "1.3.0"
       }
     },
     "loggly": {
@@ -14140,9 +14140,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "json-stringify-safe": "5.0.x",
-        "request": "2.75.x",
-        "timespan": "2.3.x"
+        "json-stringify-safe": "5.0.1",
+        "request": "2.75.0",
+        "timespan": "2.3.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -14166,7 +14166,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "readable-stream": "~2.0.5"
+            "readable-stream": "2.0.6"
           }
         },
         "boom": {
@@ -14175,7 +14175,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "caseless": {
@@ -14192,7 +14192,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "form-data": {
@@ -14202,9 +14202,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.11"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
           }
         },
         "hawk": {
@@ -14214,10 +14214,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -14233,9 +14233,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
         "isarray": {
@@ -14257,7 +14257,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "~1.30.0"
+            "mime-db": "1.30.0"
           }
         },
         "oauth-sign": {
@@ -14281,12 +14281,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
@@ -14296,27 +14296,27 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "bl": "~1.1.2",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.0.0",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "node-uuid": "~1.4.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.2.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.0.0",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.3",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3"
           }
         },
         "sntp": {
@@ -14326,7 +14326,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         }
       }
@@ -14344,8 +14344,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -14361,10 +14361,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "indent-string": "^2.1.0",
-        "longest": "^1.0.0",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "indent-string": "2.1.0",
+        "longest": "1.0.1",
+        "meow": "3.7.0"
       }
     },
     "lru-cache": {
@@ -14391,15 +14391,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "~2.1.2",
-        "debug": "~2.2.0",
-        "form-data": "~2.1.1",
-        "inflection": "~1.10.0",
-        "is-stream": "^1.1.0",
-        "path-proxy": "~1.0.0",
-        "proxy-agent": "~2.0.0",
-        "q": "~1.4.0",
-        "tsscmp": "~1.0.0"
+        "async": "2.1.5",
+        "debug": "2.2.0",
+        "form-data": "2.1.4",
+        "inflection": "1.10.0",
+        "is-stream": "1.1.0",
+        "path-proxy": "1.0.0",
+        "proxy-agent": "2.0.0",
+        "q": "1.4.1",
+        "tsscmp": "1.0.5"
       },
       "dependencies": {
         "debug": {
@@ -14419,9 +14419,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
           }
         },
         "mime-db": {
@@ -14438,7 +14438,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mime-db": "~1.30.0"
+            "mime-db": "1.30.0"
           }
         },
         "ms": {
@@ -14463,7 +14463,7 @@
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -14486,7 +14486,7 @@
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "dev": true,
       "requires": {
-        "make-error": "^1.2.0"
+        "make-error": "1.3.2"
       }
     },
     "make-iterator": {
@@ -14495,7 +14495,7 @@
       "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.1.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -14504,7 +14504,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -14533,7 +14533,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "math-clamp-x": {
@@ -14543,7 +14543,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "to-number-x": "^2.0.0"
+        "to-number-x": "2.0.0"
       }
     },
     "math-sign-x": {
@@ -14553,8 +14553,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-nan-x": "^1.0.1",
-        "to-number-x": "^2.0.0"
+        "is-nan-x": "1.0.1",
+        "to-number-x": "2.0.0"
       }
     },
     "max-safe-integer": {
@@ -14570,8 +14570,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       },
       "dependencies": {
         "hash-base": {
@@ -14580,8 +14580,8 @@
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -14604,16 +14604,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -14636,7 +14636,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -14651,13 +14651,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -14666,7 +14666,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -14683,19 +14683,19 @@
       "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.0",
-        "define-property": "^1.0.0",
-        "extend-shallow": "^2.0.1",
-        "extglob": "^2.0.2",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.0",
-        "nanomatch": "^1.2.5",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.0",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.7",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
       }
     },
     "miller-rabin": {
@@ -14704,8 +14704,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -14726,7 +14726,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "minimalistic-assert": {
@@ -14747,7 +14747,7 @@
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.0.0"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -14762,8 +14762,8 @@
       "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -14772,7 +14772,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -14800,21 +14800,21 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
-        "browser-resolve": "^1.7.0",
-        "cached-path-relative": "^1.0.0",
-        "concat-stream": "~1.5.0",
-        "defined": "^1.0.0",
-        "detective": "^4.0.0",
-        "duplexer2": "^0.1.2",
-        "inherits": "^2.0.1",
-        "parents": "^1.0.0",
-        "readable-stream": "^2.0.2",
-        "resolve": "^1.1.3",
-        "stream-combiner2": "^1.1.1",
-        "subarg": "^1.0.0",
-        "through2": "^2.0.0",
-        "xtend": "^4.0.0"
+        "JSONStream": "1.3.2",
+        "browser-resolve": "1.11.2",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "defined": "1.0.0",
+        "detective": "4.7.1",
+        "duplexer2": "0.1.4",
+        "inherits": "2.0.3",
+        "parents": "1.0.1",
+        "readable-stream": "2.3.3",
+        "resolve": "1.5.0",
+        "stream-combiner2": "1.1.1",
+        "subarg": "1.0.0",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "concat-stream": {
@@ -14823,9 +14823,9 @@
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~2.0.0",
-            "typedarray": "~0.0.5"
+            "inherits": "2.0.3",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
           },
           "dependencies": {
             "readable-stream": {
@@ -14834,12 +14834,12 @@
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
               }
             }
           }
@@ -14850,7 +14850,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.3"
           }
         },
         "isarray": {
@@ -14865,13 +14865,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
             "string_decoder": {
@@ -14880,7 +14880,7 @@
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -14924,17 +14924,17 @@
       "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^1.0.0",
-        "kind-of": "^5.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "is-odd": "1.0.0",
+        "kind-of": "5.1.0",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.0",
+        "snapdragon": "0.8.1",
+        "to-regex": "3.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -14957,7 +14957,7 @@
       "integrity": "sha1-LuEhG8n6bkxVcV/SELsFYC6xrjs=",
       "dev": true,
       "requires": {
-        "varstream": "^0.3.2"
+        "varstream": "0.3.2"
       }
     },
     "negotiator": {
@@ -14979,18 +14979,18 @@
       "integrity": "sha1-3D/FG6Cy+LOF2+BH9NoG9YCh/WE=",
       "dev": true,
       "requires": {
-        "acorn": "~2.6.4",
-        "alter": "~0.2.0",
-        "convert-source-map": "~1.1.2",
-        "optimist": "~0.6.1",
-        "ordered-ast-traverse": "~1.1.1",
-        "simple-fmt": "~0.1.0",
-        "simple-is": "~0.2.0",
-        "source-map": "~0.5.3",
-        "stable": "~0.1.5",
-        "stringmap": "~0.2.2",
-        "stringset": "~0.2.1",
-        "tryor": "~0.1.2"
+        "acorn": "2.6.4",
+        "alter": "0.2.0",
+        "convert-source-map": "1.1.3",
+        "optimist": "0.6.1",
+        "ordered-ast-traverse": "1.1.1",
+        "simple-fmt": "0.1.0",
+        "simple-is": "0.2.0",
+        "source-map": "0.5.7",
+        "stable": "0.1.6",
+        "stringmap": "0.2.2",
+        "stringset": "0.2.1",
+        "tryor": "0.1.2"
       },
       "dependencies": {
         "convert-source-map": {
@@ -15006,7 +15006,7 @@
       "resolved": "https://registry.npmjs.org/ng-idle/-/ng-idle-1.3.2.tgz",
       "integrity": "sha1-c6TcwKbINgMQ0Tlt83a+a9CwqGc=",
       "requires": {
-        "angular": "^1.2.0"
+        "angular": "1.6.8"
       }
     },
     "ng-text-truncate": {
@@ -15020,19 +15020,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "2",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.4",
+        "request": "2.83.0",
+        "rimraf": "2.2.8",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "fstream": {
@@ -15041,10 +15041,10 @@
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.2.8"
           }
         },
         "glob": {
@@ -15053,12 +15053,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
@@ -15073,7 +15073,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "semver": {
@@ -15088,9 +15088,9 @@
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         }
       }
@@ -15101,25 +15101,25 @@
       "integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
       "dev": true,
       "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
-        "node-gyp": "^3.8.0",
-        "npmlog": "^4.0.0",
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.3",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.3",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.1",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.11.0",
+        "node-gyp": "3.8.0",
+        "npmlog": "4.1.2",
         "request": "2.87.0",
-        "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.1",
+        "true-case-path": "1.0.3"
       },
       "dependencies": {
         "cross-spawn": {
@@ -15128,8 +15128,8 @@
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "which": "1.3.0"
           }
         },
         "gaze": {
@@ -15138,7 +15138,7 @@
           "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
           "dev": true,
           "requires": {
-            "globule": "^1.0.0"
+            "globule": "1.2.1"
           }
         },
         "glob": {
@@ -15147,12 +15147,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "globule": {
@@ -15161,9 +15161,9 @@
           "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
           "dev": true,
           "requires": {
-            "glob": "~7.1.1",
-            "lodash": "~4.17.10",
-            "minimatch": "~3.0.2"
+            "glob": "7.1.3",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4"
           }
         },
         "graceful-fs": {
@@ -15178,8 +15178,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "lodash": {
@@ -15194,8 +15194,8 @@
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "minimatch": {
@@ -15204,7 +15204,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "nan": {
@@ -15219,18 +15219,18 @@
           "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
           "dev": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "^2.87.0",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
+            "fstream": "1.0.11",
+            "glob": "7.1.3",
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.4",
+            "request": "2.87.0",
+            "rimraf": "2.2.8",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.0"
           }
         },
         "qs": {
@@ -15245,26 +15245,26 @@
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.1",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "semver": {
@@ -15279,7 +15279,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.1"
           }
         },
         "uuid": {
@@ -15332,8 +15332,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ip": "^1.1.2",
-            "smart-buffer": "^1.0.4"
+            "ip": "1.1.5",
+            "smart-buffer": "1.1.15"
           }
         }
       }
@@ -15400,7 +15400,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.0.9"
       }
     },
     "normalize-package-data": {
@@ -15409,10 +15409,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "4.3.6",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -15421,7 +15421,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-space-x": {
@@ -15430,9 +15430,9 @@
       "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
       "dev": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "trim-x": "^3.0.0",
-        "white-space-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "trim-x": "3.0.0",
+        "white-space-x": "3.0.0"
       }
     },
     "npm-run-path": {
@@ -15442,7 +15442,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -15451,10 +15451,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "nth-check": {
@@ -15464,7 +15464,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "null-check": {
@@ -15502,9 +15502,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -15513,7 +15513,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -15522,7 +15522,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-data-descriptor": {
@@ -15531,7 +15531,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
@@ -15540,9 +15540,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -15559,7 +15559,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -15571,16 +15571,16 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "attempt-x": "^1.1.0",
-        "has-own-property-x": "^3.1.1",
-        "has-symbol-support-x": "^1.4.1",
-        "is-falsey-x": "^1.0.0",
-        "is-index-x": "^1.0.0",
-        "is-primitive": "^2.0.0",
-        "is-string": "^1.0.4",
-        "property-is-enumerable-x": "^1.1.0",
-        "to-object-x": "^1.4.1",
-        "to-property-key-x": "^2.0.1"
+        "attempt-x": "1.1.1",
+        "has-own-property-x": "3.2.0",
+        "has-symbol-support-x": "1.4.1",
+        "is-falsey-x": "1.0.1",
+        "is-index-x": "1.1.0",
+        "is-primitive": "2.0.0",
+        "is-string": "1.0.4",
+        "property-is-enumerable-x": "1.1.0",
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
       }
     },
     "object-keys": {
@@ -15601,7 +15601,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.defaults": {
@@ -15610,10 +15610,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -15623,8 +15623,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "object.map": {
@@ -15633,8 +15633,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.0"
       }
     },
     "object.omit": {
@@ -15643,8 +15643,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       },
       "dependencies": {
         "for-own": {
@@ -15653,7 +15653,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -15664,7 +15664,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "object.values": {
@@ -15674,10 +15674,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.1"
       }
     },
     "on-finished": {
@@ -15695,7 +15695,7 @@
       "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -15716,8 +15716,8 @@
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
       }
     },
     "optimist": {
@@ -15726,8 +15726,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -15745,12 +15745,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -15769,9 +15769,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "orchestrator": {
@@ -15780,9 +15780,9 @@
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
-        "end-of-stream": "~0.1.5",
-        "sequencify": "~0.0.7",
-        "stream-consume": "~0.1.0"
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.0"
       }
     },
     "ordered-ast-traverse": {
@@ -15791,7 +15791,7 @@
       "integrity": "sha1-aEOhcLwO7otSDMjdwd3TqjD6BXw=",
       "dev": true,
       "requires": {
-        "ordered-esprima-props": "~1.1.0"
+        "ordered-esprima-props": "1.1.0"
       }
     },
     "ordered-esprima-props": {
@@ -15831,7 +15831,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -15846,8 +15846,8 @@
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "p-finally": {
@@ -15869,15 +15869,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3",
-        "get-uri": "2",
-        "http-proxy-agent": "1",
-        "https-proxy-agent": "1",
-        "pac-resolver": "~2.0.0",
-        "raw-body": "2",
-        "socks-proxy-agent": "2"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "get-uri": "2.0.1",
+        "http-proxy-agent": "1.0.0",
+        "https-proxy-agent": "1.0.0",
+        "pac-resolver": "2.0.0",
+        "raw-body": "2.3.2",
+        "socks-proxy-agent": "2.1.1"
       }
     },
     "pac-resolver": {
@@ -15887,11 +15887,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "co": "~3.0.6",
-        "degenerator": "~1.0.2",
+        "co": "3.0.6",
+        "degenerator": "1.0.4",
         "ip": "1.0.1",
-        "netmask": "~1.0.4",
-        "thunkify": "~2.1.1"
+        "netmask": "1.0.6",
+        "thunkify": "2.1.2"
       },
       "dependencies": {
         "co": {
@@ -15920,7 +15920,7 @@
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "~0.11.15"
+        "path-platform": "0.11.15"
       }
     },
     "parse-asn1": {
@@ -15929,11 +15929,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.9.2",
+        "browserify-aes": "1.1.1",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
       }
     },
     "parse-filepath": {
@@ -15942,9 +15942,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -15953,10 +15953,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -15971,7 +15971,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -15982,10 +15982,10 @@
       "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
       "dev": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "nan-x": "^1.0.0",
-        "to-string-x": "^1.4.2",
-        "trim-left-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "nan-x": "1.0.0",
+        "to-string-x": "1.4.2",
+        "trim-left-x": "3.0.0"
       }
     },
     "parse-json": {
@@ -15994,7 +15994,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-passwd": {
@@ -16008,7 +16008,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -16016,7 +16016,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -16049,7 +16049,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -16084,7 +16084,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "inflection": "~1.3.0"
+        "inflection": "1.3.8"
       },
       "dependencies": {
         "inflection": {
@@ -16102,7 +16102,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -16117,9 +16117,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -16136,11 +16136,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.10"
       }
     },
     "pend": {
@@ -16161,14 +16161,14 @@
       "integrity": "sha1-RCSsog4U0lXAsIia9va4lz2hDg0=",
       "dev": true,
       "requires": {
-        "extract-zip": "~1.5.0",
-        "fs-extra": "~0.26.4",
-        "hasha": "^2.2.0",
-        "kew": "~0.7.0",
-        "progress": "~1.1.8",
-        "request": "~2.67.0",
-        "request-progress": "~2.0.1",
-        "which": "~1.2.2"
+        "extract-zip": "1.5.0",
+        "fs-extra": "0.26.7",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.67.0",
+        "request-progress": "2.0.1",
+        "which": "1.2.14"
       },
       "dependencies": {
         "assert-plus": {
@@ -16183,7 +16183,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.4"
           }
         },
         "aws-sign2": {
@@ -16198,7 +16198,7 @@
           "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.0.5"
+            "readable-stream": "2.0.6"
           }
         },
         "boom": {
@@ -16207,7 +16207,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "caseless": {
@@ -16222,7 +16222,7 @@
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "cryptiles": {
@@ -16231,7 +16231,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "delayed-stream": {
@@ -16258,9 +16258,9 @@
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
           "dev": true,
           "requires": {
-            "async": "^2.0.1",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.11"
+            "async": "2.6.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
           }
         },
         "hawk": {
@@ -16269,10 +16269,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -16287,9 +16287,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
         "isarray": {
@@ -16316,7 +16316,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "~1.30.0"
+            "mime-db": "1.30.0"
           }
         },
         "oauth-sign": {
@@ -16337,12 +16337,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
@@ -16351,26 +16351,26 @@
           "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "bl": "~1.0.0",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~1.0.0-rc3",
-            "har-validator": "~2.0.2",
-            "hawk": "~3.1.0",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "node-uuid": "~1.4.7",
-            "oauth-sign": "~0.8.0",
-            "qs": "~5.2.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.2.0",
-            "tunnel-agent": "~0.4.1"
+            "aws-sign2": "0.6.0",
+            "bl": "1.0.3",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.1",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "5.2.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.2",
+            "tunnel-agent": "0.4.3"
           }
         },
         "request-progress": {
@@ -16379,7 +16379,7 @@
           "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
           "dev": true,
           "requires": {
-            "throttleit": "^1.0.0"
+            "throttleit": "1.0.0"
           }
         },
         "sntp": {
@@ -16388,7 +16388,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "throttleit": {
@@ -16409,7 +16409,7 @@
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         }
       }
@@ -16432,7 +16432,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plexer": {
@@ -16442,8 +16442,8 @@
       "dev": true,
       "requires": {
         "debug": "2.6.1",
-        "isstream": "^0.1.2",
-        "readable-stream": "^2.0.2"
+        "isstream": "0.1.2",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "debug": {
@@ -16473,13 +16473,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -16488,7 +16488,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -16499,11 +16499,11 @@
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "dev": true,
       "requires": {
-        "ansi-cyan": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "arr-diff": "^1.0.1",
-        "arr-union": "^2.0.1",
-        "extend-shallow": "^1.1.2"
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
       },
       "dependencies": {
         "arr-diff": {
@@ -16512,8 +16512,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "arr-union": {
@@ -16534,7 +16534,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "^1.1.0"
+            "kind-of": "1.1.0"
           }
         },
         "kind-of": {
@@ -16551,7 +16551,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "portscanner": {
@@ -16561,7 +16561,7 @@
       "dev": true,
       "requires": {
         "async": "1.5.2",
-        "is-number-like": "^1.0.3"
+        "is-number-like": "1.0.8"
       },
       "dependencies": {
         "async": {
@@ -16583,7 +16583,7 @@
       "resolved": "https://registry.npmjs.org/postal/-/postal-2.0.5.tgz",
       "integrity": "sha1-f58DWUOiTaqZY6xaU7XQzwffJLk=",
       "requires": {
-        "lodash": "^4.12.0"
+        "lodash": "4.17.4"
       }
     },
     "prelude-ls": {
@@ -16641,8 +16641,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "to-object-x": "^1.4.1",
-        "to-property-key-x": "^2.0.1"
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
       }
     },
     "proxy-agent": {
@@ -16652,14 +16652,14 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3",
-        "http-proxy-agent": "1",
-        "https-proxy-agent": "1",
-        "lru-cache": "~2.6.5",
-        "pac-proxy-agent": "1",
-        "socks-proxy-agent": "2"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "http-proxy-agent": "1.0.0",
+        "https-proxy-agent": "1.0.0",
+        "lru-cache": "2.6.5",
+        "pac-proxy-agent": "1.1.0",
+        "socks-proxy-agent": "2.1.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -16683,11 +16683,11 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.6"
       }
     },
     "punycode": {
@@ -16726,8 +16726,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -16736,7 +16736,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -16747,7 +16747,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "randomfill": {
@@ -16756,8 +16756,8 @@
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "dev": true,
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "range-parser": {
@@ -16765,11 +16765,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
-    },
-    "raven-js": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.22.1.tgz",
-      "integrity": "sha512-2Y8czUl5a9usbvXbpV8a+GPAiDXjxQjaHImZL0TyJWI5k5jV/6o+wceaBAg9g6RpO9OOJp0/w2mMs6pBoqOyDA=="
     },
     "raw-body": {
       "version": "2.3.2",
@@ -16789,10 +16784,10 @@
       "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
       "dev": true,
       "requires": {
-        "deep-extend": "~0.4.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "deep-extend": {
@@ -16809,7 +16804,7 @@
       "integrity": "sha1-8+gPOH3fmugK4wpBADKWQuroERU=",
       "dev": true,
       "requires": {
-        "lodash.clonedeep": "^4.3.2"
+        "lodash.clonedeep": "4.5.0"
       }
     },
     "rcloader": {
@@ -16818,10 +16813,10 @@
       "integrity": "sha1-WNIpi0YtC5v9ITPSoex0+9cFxxc=",
       "dev": true,
       "requires": {
-        "lodash.assign": "^4.2.0",
-        "lodash.isobject": "^3.0.2",
-        "lodash.merge": "^4.6.0",
-        "rcfinder": "^0.1.6"
+        "lodash.assign": "4.2.0",
+        "lodash.isobject": "3.0.2",
+        "lodash.merge": "4.6.0",
+        "rcfinder": "0.1.9"
       },
       "dependencies": {
         "lodash.isobject": {
@@ -16844,8 +16839,8 @@
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -16860,13 +16855,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -16875,7 +16870,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -16886,7 +16881,7 @@
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -16901,13 +16896,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -16916,7 +16911,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -16927,9 +16922,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -16938,8 +16933,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -16948,10 +16943,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       }
     },
     "readdirp": {
@@ -16960,10 +16955,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -16984,7 +16979,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "readable-stream": {
@@ -16993,13 +16988,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -17008,7 +17003,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -17019,7 +17014,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.5.0"
       }
     },
     "redent": {
@@ -17028,8 +17023,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "redis": {
@@ -17039,9 +17034,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "double-ended-queue": "2.1.0-0",
+        "redis-commands": "1.3.1",
+        "redis-parser": "2.6.0"
       }
     },
     "redis-commands": {
@@ -17064,7 +17059,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -17073,7 +17068,7 @@
       "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -17100,7 +17095,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-comments-x": {
@@ -17109,8 +17104,8 @@
       "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
       "dev": true,
       "requires": {
-        "require-coercible-to-string-x": "^1.0.0",
-        "to-string-x": "^1.4.2"
+        "require-coercible-to-string-x": "1.0.0",
+        "to-string-x": "1.4.2"
       }
     },
     "replace-ext": {
@@ -17125,28 +17120,28 @@
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "caseless": {
@@ -17161,9 +17156,9 @@
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
           }
         },
         "har-validator": {
@@ -17172,8 +17167,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "hawk": {
@@ -17182,10 +17177,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.x.x",
-            "cryptiles": "3.x.x",
-            "hoek": "4.x.x",
-            "sntp": "2.x.x"
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
           }
         },
         "mime-db": {
@@ -17200,7 +17195,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "~1.30.0"
+            "mime-db": "1.30.0"
           }
         },
         "oauth-sign": {
@@ -17221,7 +17216,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.1"
           }
         },
         "uuid": {
@@ -17239,10 +17234,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "extend": "^3.0.0",
-        "lodash": "^4.15.0",
-        "request": "^2.74.0",
-        "when": "^3.7.7"
+        "extend": "3.0.1",
+        "lodash": "4.17.4",
+        "request": "2.83.0",
+        "when": "3.7.8"
       }
     },
     "require-coercible-to-string-x": {
@@ -17251,8 +17246,8 @@
       "integrity": "sha512-Rpfd4sMdflPAKecdKhfAtQHlZzzle4UMUgxJ01hXtTcNWMV8w9GeZnKhEyrT73kgrflBOP1zg41amUPZGcNspA==",
       "dev": true,
       "requires": {
-        "require-object-coercible-x": "^1.4.1",
-        "to-string-x": "^1.4.2"
+        "require-object-coercible-x": "1.4.1",
+        "to-string-x": "1.4.2"
       }
     },
     "require-dir": {
@@ -17279,7 +17274,7 @@
       "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
       "dev": true,
       "requires": {
-        "is-nil-x": "^1.4.1"
+        "is-nil-x": "1.4.1"
       }
     },
     "requires-port": {
@@ -17294,7 +17289,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-dir": {
@@ -17303,8 +17298,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-url": {
@@ -17319,8 +17314,8 @@
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "minimatch": "^3.0.2"
+        "debug": "2.6.9",
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -17329,7 +17324,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -17346,8 +17341,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "^2.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
       }
     },
     "rome": {
@@ -17358,7 +17353,7 @@
         "bullseye": "1.4.6",
         "contra": "1.9.1",
         "crossvent": "1.5.0",
-        "moment": "^2.8.2"
+        "moment": "2.20.1"
       }
     },
     "run-sequence": {
@@ -17367,9 +17362,9 @@
       "integrity": "sha512-qkzZnQWMZjcKbh3CNly2srtrkaO/2H/SI5f2eliMCapdRD3UhMrwjfOAZJAnZ2H8Ju4aBzFZkBGXUqFs9V0yxw==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^0.1.2"
+        "chalk": "1.1.3",
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2"
       }
     },
     "rx": {
@@ -17389,10 +17384,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
+        "glob": "7.1.3",
+        "lodash": "4.17.4",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -17407,12 +17402,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -17421,7 +17416,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "yargs": {
@@ -17430,19 +17425,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
           }
         },
         "yargs-parser": {
@@ -17451,7 +17446,7 @@
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -17468,8 +17463,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
+        "js-base64": "2.4.9",
+        "source-map": "0.4.4"
       },
       "dependencies": {
         "source-map": {
@@ -17478,7 +17473,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -17489,7 +17484,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "~2.8.1"
+        "commander": "2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -17498,7 +17493,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         }
       }
@@ -17533,7 +17528,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "semver": {
@@ -17552,18 +17547,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "mime": {
@@ -17586,13 +17581,13 @@
       "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.3",
+        "accepts": "1.3.3",
         "batch": "0.5.3",
-        "debug": "~2.2.0",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.5.0",
-        "mime-types": "~2.1.11",
-        "parseurl": "~1.3.1"
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "http-errors": "1.5.1",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -17612,7 +17607,7 @@
           "requires": {
             "inherits": "2.0.3",
             "setprototypeof": "1.0.2",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.4.0"
           }
         },
         "ms": {
@@ -17635,9 +17630,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -17659,7 +17654,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "^0.3.0"
+        "to-object-path": "0.3.0"
       }
     },
     "set-immediate-shim": {
@@ -17674,10 +17669,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       }
     },
     "setprototypeof": {
@@ -17692,8 +17687,8 @@
       "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "shasum": {
@@ -17702,8 +17697,8 @@
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "~0.0.0",
-        "sha.js": "~2.4.4"
+        "json-stable-stringify": "0.0.1",
+        "sha.js": "2.4.10"
       },
       "dependencies": {
         "json-stable-stringify": {
@@ -17712,7 +17707,7 @@
           "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
           "dev": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         }
       }
@@ -17724,7 +17719,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -17771,7 +17766,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "requestretry": "^1.2.2"
+        "requestretry": "1.13.0"
       }
     },
     "smart-buffer": {
@@ -17796,14 +17791,14 @@
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^2.0.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -17812,7 +17807,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -17821,7 +17816,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -17830,7 +17825,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -17841,7 +17836,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -17850,7 +17845,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -17861,9 +17856,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -17880,9 +17875,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       }
     },
     "snapdragon-util": {
@@ -17891,7 +17886,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -17900,7 +17895,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -17911,7 +17906,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.0"
       }
     },
     "socket.io": {
@@ -17920,11 +17915,11 @@
       "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
       "dev": true,
       "requires": {
-        "debug": "~2.6.6",
-        "engine.io": "~3.1.0",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "2.6.9",
+        "engine.io": "3.1.4",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.0.4",
-        "socket.io-parser": "~3.1.1"
+        "socket.io-parser": "3.1.2"
       }
     },
     "socket.io-adapter": {
@@ -17942,14 +17937,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "engine.io-client": "~3.1.0",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.4",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.1.1",
+        "socket.io-parser": "3.1.2",
         "to-array": "0.1.4"
       }
     },
@@ -17959,8 +17954,8 @@
       "integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "has-binary2": "~1.0.2",
+        "debug": "2.6.9",
+        "has-binary2": "1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -17977,8 +17972,8 @@
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
       "requires": {
-        "ip": "^1.1.4",
-        "smart-buffer": "^1.0.13"
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
       },
       "dependencies": {
         "ip": {
@@ -17995,9 +17990,9 @@
       "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "extend": "3",
-        "socks": "~1.1.5"
+        "agent-base": "2.1.1",
+        "extend": "3.0.1",
+        "socks": "1.1.10"
       }
     },
     "source-map": {
@@ -18012,11 +18007,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.0.3",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-url": {
@@ -18037,7 +18032,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -18058,7 +18053,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -18067,8 +18062,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           }
         },
         "is-extendable": {
@@ -18077,7 +18072,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -18095,9 +18090,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "console-stream": "^0.1.1",
-        "lpad-align": "^1.0.1"
+        "chalk": "1.1.3",
+        "console-stream": "0.1.1",
+        "lpad-align": "1.1.2"
       }
     },
     "sshpk": {
@@ -18106,14 +18101,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "asn1": {
@@ -18148,8 +18143,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -18158,7 +18153,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -18167,7 +18162,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -18176,7 +18171,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -18187,7 +18182,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -18196,7 +18191,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -18207,9 +18202,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -18232,7 +18227,7 @@
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -18253,13 +18248,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -18268,7 +18263,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -18279,8 +18274,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -18295,13 +18290,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -18310,7 +18305,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -18321,8 +18316,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "duplexer2": {
@@ -18331,7 +18326,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.3"
           }
         },
         "isarray": {
@@ -18346,13 +18341,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -18361,7 +18356,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -18378,11 +18373,11 @@
       "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.3",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -18397,13 +18392,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -18412,7 +18407,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -18429,8 +18424,8 @@
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -18445,13 +18440,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -18460,7 +18455,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -18471,8 +18466,8 @@
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "dev": true,
       "requires": {
-        "commander": "^2.2.0",
-        "limiter": "^1.0.5"
+        "commander": "2.13.0",
+        "limiter": "1.1.3"
       }
     },
     "streamfilter": {
@@ -18481,7 +18476,7 @@
       "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -18496,13 +18491,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -18511,7 +18506,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -18522,10 +18517,10 @@
       "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
-        "date-format": "^1.2.0",
-        "debug": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "readable-stream": "^2.3.0"
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "mkdirp": "0.5.1",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "debug": {
@@ -18549,13 +18544,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -18564,7 +18559,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -18581,7 +18576,7 @@
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "dev": true,
       "requires": {
-        "strip-ansi": "^3.0.0"
+        "strip-ansi": "3.0.1"
       }
     },
     "string-width": {
@@ -18590,9 +18585,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string.fromcodepoint": {
@@ -18637,7 +18632,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -18646,8 +18641,8 @@
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "is-utf8": "^0.2.0"
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -18656,8 +18651,8 @@
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -18666,7 +18661,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -18677,12 +18672,12 @@
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "is-absolute": "^0.1.5",
-        "is-natural-number": "^2.0.0",
-        "minimist": "^1.1.0",
-        "sum-up": "^1.0.1"
+        "chalk": "1.1.3",
+        "get-stdin": "4.0.1",
+        "is-absolute": "0.1.7",
+        "is-natural-number": "2.1.1",
+        "minimist": "1.2.0",
+        "sum-up": "1.0.3"
       },
       "dependencies": {
         "is-absolute": {
@@ -18691,7 +18686,7 @@
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
           "dev": true,
           "requires": {
-            "is-relative": "^0.1.0"
+            "is-relative": "0.1.3"
           }
         },
         "is-relative": {
@@ -18715,7 +18710,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -18730,7 +18725,7 @@
       "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "subarg": {
@@ -18739,7 +18734,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.0"
+        "minimist": "1.2.0"
       }
     },
     "sum-up": {
@@ -18748,7 +18743,7 @@
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "supports-color": {
@@ -18769,12 +18764,12 @@
       "integrity": "sha1-ggIuVovQPBq7Zo/djRXwCJVqDhA=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.6",
-        "cubic2quad": "^1.0.0",
-        "lodash": "^4.6.1",
-        "microbuffer": "^1.0.0",
-        "svgpath": "^2.1.5",
-        "xmldom": "~0.1.22"
+        "argparse": "1.0.9",
+        "cubic2quad": "1.1.1",
+        "lodash": "4.17.4",
+        "microbuffer": "1.0.0",
+        "svgpath": "2.2.1",
+        "xmldom": "0.1.27"
       }
     },
     "svgicons2svgfont": {
@@ -18783,17 +18778,17 @@
       "integrity": "sha512-6nYfGwbNo9urXMsan3r59raSs+f6VkluGsKSKAyQtyon/wrX5lDDml4EP20AsMVwoG5YfMfOn91AQ8ZqF9WeGg==",
       "dev": true,
       "requires": {
-        "commander": "^2.9.0",
+        "commander": "2.13.0",
         "debug": "2.6.1",
-        "geometry-interfaces": "^1.1.4",
-        "glob": "^7.1.2",
-        "neatequal": "^1.0.0",
-        "readable-stream": "^2.0.4",
-        "sax": "^1.1.5",
-        "string.fromcodepoint": "^0.2.1",
-        "string.prototype.codepointat": "^0.2.0",
-        "svg-pathdata": "^4.0.1",
-        "transformation-matrix-js": "^2.7.1"
+        "geometry-interfaces": "1.1.4",
+        "glob": "7.1.2",
+        "neatequal": "1.0.0",
+        "readable-stream": "2.3.3",
+        "sax": "1.2.4",
+        "string.fromcodepoint": "0.2.1",
+        "string.prototype.codepointat": "0.2.0",
+        "svg-pathdata": "4.0.1",
+        "transformation-matrix-js": "2.7.1"
       },
       "dependencies": {
         "debug": {
@@ -18811,12 +18806,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "isarray": {
@@ -18831,7 +18826,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "ms": {
@@ -18846,13 +18841,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -18861,7 +18856,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -18873,20 +18868,20 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "coa": "~2.0.0",
-        "colors": "~1.1.2",
-        "css-select": "~1.3.0-rc0",
-        "css-select-base-adapter": "~0.1.0",
+        "coa": "2.0.1",
+        "colors": "1.1.2",
+        "css-select": "1.3.0-rc0",
+        "css-select-base-adapter": "0.1.0",
         "css-tree": "1.0.0-alpha25",
-        "css-url-regex": "^1.1.0",
-        "csso": "^3.3.1",
-        "js-yaml": "~3.10.0",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.0.4",
-        "sax": "~1.2.4",
-        "stable": "~0.1.6",
-        "unquote": "^1.1.0",
-        "util.promisify": "~1.0.0"
+        "css-url-regex": "1.1.0",
+        "csso": "3.5.0",
+        "js-yaml": "3.10.0",
+        "mkdirp": "0.5.1",
+        "object.values": "1.0.4",
+        "sax": "1.2.4",
+        "stable": "0.1.6",
+        "unquote": "1.1.1",
+        "util.promisify": "1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -18903,8 +18898,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
           }
         }
       }
@@ -18921,7 +18916,7 @@
       "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.3"
+        "acorn": "4.0.13"
       },
       "dependencies": {
         "acorn": {
@@ -18938,9 +18933,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
       }
     },
     "tar-stream": {
@@ -18949,10 +18944,10 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "^1.0.0",
-        "end-of-stream": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "bl": {
@@ -18961,7 +18956,7 @@
           "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.5"
+            "readable-stream": "2.3.3"
           }
         },
         "end-of-stream": {
@@ -18970,7 +18965,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -18985,7 +18980,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "readable-stream": {
@@ -18994,13 +18989,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -19009,7 +19004,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -19028,8 +19023,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "temp-dir": "^1.0.0",
-        "uuid": "^3.0.1"
+        "temp-dir": "1.0.0",
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "uuid": {
@@ -19053,8 +19048,8 @@
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "object-path": "^0.9.0"
+        "chalk": "1.1.3",
+        "object-path": "0.9.2"
       }
     },
     "through": {
@@ -19069,8 +19064,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -19085,13 +19080,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -19100,7 +19095,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -19111,7 +19106,7 @@
       "integrity": "sha1-EctOpMnjG8puTB5tukjRxyjDUks=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.0"
+        "through2": "2.0.3"
       }
     },
     "through2-filter": {
@@ -19120,8 +19115,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "thunkify": {
@@ -19142,7 +19137,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "time-stamp": {
@@ -19157,7 +19152,7 @@
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "~0.11.0"
+        "process": "0.11.10"
       }
     },
     "timespan": {
@@ -19173,7 +19168,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -19182,7 +19177,7 @@
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       }
     },
     "to-array": {
@@ -19208,7 +19203,7 @@
       "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
       "dev": true,
       "requires": {
-        "to-space-case": "^1.0.0"
+        "to-space-case": "1.0.0"
       }
     },
     "to-integer-x": {
@@ -19218,10 +19213,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-finite-x": "^3.0.2",
-        "is-nan-x": "^1.0.1",
-        "math-sign-x": "^3.0.0",
-        "to-number-x": "^2.0.0"
+        "is-finite-x": "3.0.2",
+        "is-nan-x": "1.0.1",
+        "math-sign-x": "3.0.0",
+        "to-number-x": "2.0.0"
       }
     },
     "to-no-case": {
@@ -19236,11 +19231,11 @@
       "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
       "dev": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "nan-x": "^1.0.0",
-        "parse-int-x": "^2.0.0",
-        "to-primitive-x": "^1.1.0",
-        "trim-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "nan-x": "1.0.0",
+        "parse-int-x": "2.0.0",
+        "to-primitive-x": "1.1.0",
+        "trim-x": "3.0.0"
       }
     },
     "to-object-path": {
@@ -19249,7 +19244,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -19258,7 +19253,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -19269,8 +19264,8 @@
       "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
       "dev": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-object-coercible-x": "^1.4.1"
+        "cached-constructors-x": "1.0.0",
+        "require-object-coercible-x": "1.4.1"
       }
     },
     "to-primitive-x": {
@@ -19279,14 +19274,14 @@
       "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1",
-        "is-date-object": "^1.0.1",
-        "is-function-x": "^3.2.0",
-        "is-nil-x": "^1.4.1",
-        "is-primitive": "^2.0.0",
-        "is-symbol": "^1.0.1",
-        "require-object-coercible-x": "^1.4.1",
-        "validate.io-undefined": "^1.0.3"
+        "has-symbol-support-x": "1.4.1",
+        "is-date-object": "1.0.1",
+        "is-function-x": "3.3.0",
+        "is-nil-x": "1.4.1",
+        "is-primitive": "2.0.0",
+        "is-symbol": "1.0.1",
+        "require-object-coercible-x": "1.4.1",
+        "validate.io-undefined": "1.0.3"
       }
     },
     "to-property-key-x": {
@@ -19295,9 +19290,9 @@
       "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1",
-        "to-primitive-x": "^1.1.0",
-        "to-string-x": "^1.4.2"
+        "has-symbol-support-x": "1.4.1",
+        "to-primitive-x": "1.1.0",
+        "to-string-x": "1.4.2"
       }
     },
     "to-regex": {
@@ -19306,9 +19301,9 @@
       "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "regex-not": "^1.0.0"
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "regex-not": "1.0.0"
       },
       "dependencies": {
         "define-property": {
@@ -19317,7 +19312,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -19326,7 +19321,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -19335,7 +19330,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -19346,7 +19341,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -19355,7 +19350,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -19366,9 +19361,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -19385,8 +19380,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "to-space-case": {
@@ -19395,7 +19390,7 @@
       "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
       "dev": true,
       "requires": {
-        "to-no-case": "^1.0.0"
+        "to-no-case": "1.0.2"
       }
     },
     "to-string-symbols-supported-x": {
@@ -19405,9 +19400,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "has-symbol-support-x": "^1.4.1",
-        "is-symbol": "^1.0.1"
+        "cached-constructors-x": "1.0.0",
+        "has-symbol-support-x": "1.4.1",
+        "is-symbol": "1.0.1"
       }
     },
     "to-string-tag-x": {
@@ -19416,8 +19411,8 @@
       "integrity": "sha512-ytO9eLigxsQQLGuab0C1iSSTzKdJNVSlBg0Spg4J/rGAVrQJ5y774mo0SSzgGeTT4RJGGyJNfObXaTMzX0XDOQ==",
       "dev": true,
       "requires": {
-        "lodash.isnull": "^3.0.0",
-        "validate.io-undefined": "^1.0.3"
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
       }
     },
     "to-string-x": {
@@ -19426,7 +19421,7 @@
       "integrity": "sha512-/WP5arlwtCpAAexCCHiQBW0eXwse84osWyP1Qtaz71nsYSuUpOkT6tBm8nQ4IIUfSh5hji0hDupUCD2xbbOL6A==",
       "dev": true,
       "requires": {
-        "is-symbol": "^1.0.1"
+        "is-symbol": "1.0.1"
       }
     },
     "tough-cookie": {
@@ -19435,7 +19430,7 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "transformation-matrix-js": {
@@ -19450,9 +19445,9 @@
       "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
       "dev": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-coercible-to-string-x": "^1.0.0",
-        "white-space-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "require-coercible-to-string-x": "1.0.0",
+        "white-space-x": "3.0.0"
       }
     },
     "trim-newlines": {
@@ -19467,7 +19462,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "trim-right-x": {
@@ -19476,9 +19471,9 @@
       "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
       "dev": true,
       "requires": {
-        "cached-constructors-x": "^1.0.0",
-        "require-coercible-to-string-x": "^1.0.0",
-        "white-space-x": "^3.0.0"
+        "cached-constructors-x": "1.0.0",
+        "require-coercible-to-string-x": "1.0.0",
+        "white-space-x": "3.0.0"
       }
     },
     "trim-x": {
@@ -19487,8 +19482,8 @@
       "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
       "dev": true,
       "requires": {
-        "trim-left-x": "^3.0.0",
-        "trim-right-x": "^3.0.0"
+        "trim-left-x": "3.0.0",
+        "trim-right-x": "3.0.0"
       }
     },
     "true-case-path": {
@@ -19497,7 +19492,7 @@
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.2"
+        "glob": "7.1.3"
       },
       "dependencies": {
         "glob": {
@@ -19506,12 +19501,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -19520,7 +19515,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -19544,8 +19539,8 @@
       "integrity": "sha1-jmM3pYWr0WCKDISVirSDzmn2ZUs=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.6",
-        "microbuffer": "^1.0.0"
+        "argparse": "1.0.9",
+        "microbuffer": "1.0.0"
       }
     },
     "ttf2woff": {
@@ -19554,9 +19549,9 @@
       "integrity": "sha1-hxgyJAAksJ25VwkEx8GSi4BXyWk=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.6",
-        "microbuffer": "^1.0.0",
-        "pako": "^1.0.0"
+        "argparse": "1.0.9",
+        "microbuffer": "1.0.0",
+        "pako": "1.0.6"
       }
     },
     "ttf2woff2": {
@@ -19565,10 +19560,10 @@
       "integrity": "sha1-XgIK/m5kMofzrXaHq+0g/mVOsyk=",
       "dev": true,
       "requires": {
-        "bindings": "^1.2.1",
-        "bufferstreams": "^1.1.0",
-        "nan": "^2.1.0",
-        "node-gyp": "^3.0.3"
+        "bindings": "1.3.0",
+        "bufferstreams": "1.1.3",
+        "nan": "2.8.0",
+        "node-gyp": "3.6.2"
       }
     },
     "tty-browserify": {
@@ -19596,7 +19591,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -19606,7 +19601,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
+        "mime-types": "2.1.17"
       },
       "dependencies": {
         "mime-db": {
@@ -19621,7 +19616,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "~1.30.0"
+            "mime-db": "1.30.0"
           }
         }
       }
@@ -19667,10 +19662,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "set-value": {
@@ -19679,10 +19674,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -19718,8 +19713,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -19728,9 +19723,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -19794,7 +19789,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-regex": {
@@ -19804,7 +19799,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "ip-regex": "^1.0.1"
+        "ip-regex": "1.0.3"
       }
     },
     "use": {
@@ -19813,9 +19808,9 @@
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "lazy-cache": "^2.0.2"
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "lazy-cache": "2.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -19824,7 +19819,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -19833,7 +19828,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -19842,7 +19837,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -19853,7 +19848,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -19862,7 +19857,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -19873,9 +19868,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -19898,8 +19893,8 @@
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.2.x",
-        "tmp": "0.0.x"
+        "lru-cache": "2.2.4",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "lru-cache": {
@@ -19940,8 +19935,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "utils-merge": {
@@ -19963,7 +19958,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       }
     },
     "vali-date": {
@@ -19978,8 +19973,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "validate.io-undefined": {
@@ -19994,7 +19989,7 @@
       "integrity": "sha1-GKxklHZfP/GjWtmkvgU77BiKXeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^1.0.33"
+        "readable-stream": "1.1.14"
       }
     },
     "verror": {
@@ -20003,9 +19998,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -20022,8 +20017,8 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.3",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -20033,8 +20028,8 @@
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "readable-stream": "^2.0.0"
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.3"
       },
       "dependencies": {
         "isarray": {
@@ -20055,13 +20050,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -20070,7 +20065,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -20081,14 +20076,14 @@
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.0",
-        "glob-stream": "^3.1.5",
-        "glob-watcher": "^0.0.6",
-        "graceful-fs": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "strip-bom": "^1.0.0",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.0"
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -20103,10 +20098,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -20115,8 +20110,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -20125,8 +20120,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -20137,7 +20132,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "0.5.7"
       }
     },
     "vm-browserify": {
@@ -20161,7 +20156,7 @@
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "dev": true,
       "requires": {
-        "wrap-fn": "^0.1.0"
+        "wrap-fn": "0.1.5"
       }
     },
     "when": {
@@ -20177,7 +20172,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -20198,7 +20193,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "1.0.2"
       }
     },
     "window-size": {
@@ -20219,8 +20214,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrap-fn": {
@@ -20251,9 +20246,9 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "ultron": "1.1.1"
       }
     },
     "xmlbuilder": {
@@ -20304,20 +20299,20 @@
       "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^4.1.0"
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
       },
       "dependencies": {
         "camelcase": {
@@ -20334,7 +20329,7 @@
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -20351,8 +20346,8 @@
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.0.1"
       }
     },
     "yeast": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ng-text-truncate": "^1.0.0",
     "papaparse": "^4.3.6",
     "postal": "^2.0.5",
-    "raven-js": "^3.22.1",
     "rome": "^2.1.22",
     "socket.io-client": "^2.0.4"
   },

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,6 @@ git+git://github.com/ministryofjustice/cla_common.git@0.3.10#egg=cla_common
 
 django-proxy==1.0.2
 django-csp==2.0.3
-raven==5.1.1
 django-session-security==2.2.3
 django-statsd-mozilla==0.3.14
 logstash-formatter==0.5.9
@@ -22,6 +21,7 @@ pyjade==3.0.0
 websocket-client==0.23.0
 requests==2.19.1
 django-extended-choices==0.3.0
+sentry-sdk==0.19.2
 
 #Irat healthcheck and ping package
 git+https://github.com/ministryofjustice/django-moj-irat.git@4d54b86b1cb574fe787ba0fb8a992cf352f8eba6


### PR DESCRIPTION
## What does this pull request do?

Switches from Raven library to Sentry SDK, and starts passing an environment tag.

## Any other changes that would benefit highlighting?

- SENTRY_DSN value, which has now been added using cla_frontend-deploy
- Removed raven front-end(javascript) integration as the upgrade work for that needs to be done as part of https://dsdmoj.atlassian.net/browse/LGA-1494
- Pin pip to version 18.1 as the latest pip21 dropped support for python2.7

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
