### PR TITLE
LGA-1494 - Sentry integration with the Angular frontend

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,8 @@
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "moment-timezone": "~0.3.1",
     "angular-sticky": "angular-sticky-plugin#^0.4.2",
-    "angulartics-google-analytics": "0.5.0"
+    "angulartics-google-analytics": "0.5.0",
+    "raven-js": "3.27.2"
   },
   "resolutions": {
     "angular": "1.4.13",

--- a/cla_frontend/apps/core/context_processors.py
+++ b/cla_frontend/apps/core/context_processors.py
@@ -8,7 +8,7 @@ def globals(request):
         "phase": "alpha",
         "product_type": "service",
         "feedback_url": "#",
-        "raven_config_site": "",
+        "sentry_public_dsn": settings.SENTRY_PUBLIC_DSN,
         "socketio_server_url": settings.SOCKETIO_SERVER_URL,
         "analytics_id": settings.ANALYTICS_ID,
         "analytics_domain": settings.ANALYTICS_DOMAIN,

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -146,7 +146,7 @@
       'angularUtils.directives.dirPagination',
       'ngTextTruncate',
       'ngIdle',
-      "ngRaven"
+      'ngRaven'
     ])
     .config(common_config)
     .run(common_run);
@@ -201,7 +201,8 @@
       'diff-match-patch',
       'angularUtils.directives.dirPagination',
       'ngTextTruncate',
-      'ngIdle'
+      'ngIdle',
+      'ngRaven'
     ])
     .config(common_config)
     .run(common_run);

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -145,7 +145,8 @@
       'diff-match-patch',
       'angularUtils.directives.dirPagination',
       'ngTextTruncate',
-      'ngIdle'
+      'ngIdle',
+      "ngRaven"
     ])
     .config(common_config)
     .run(common_run);

--- a/cla_frontend/assets-src/javascripts/app/js/services/network.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/network.js
@@ -45,8 +45,8 @@
       };
     }])
 
-    .factory('cla.httpInterceptor', ['$q', 'flash', '$injector', '$sce', 'form_utils', 'url_utils', 'postal',
-      function($q, flash, $injector, $sce, form_utils, url_utils, postal) {
+    .factory('cla.httpInterceptor', ['$q', 'flash', '$injector', '$sce', 'form_utils', 'url_utils', 'postal', 'Raven',
+      function($q, flash, $injector, $sce, form_utils, url_utils, postal, Raven) {
         return {
           // optional method
           responseError: function(rejection) {
@@ -80,6 +80,7 @@
               }
 
               if (msg) {
+                Raven.captureException(new Error(msg));
                 flash('error', msg);
               }
             }

--- a/cla_frontend/assets-src/javascripts/vendor/raven.config.js
+++ b/cla_frontend/assets-src/javascripts/vendor/raven.config.js
@@ -1,9 +1,4 @@
 var dsn = document.getElementsByTagName('head')[0].getAttribute('data-sentry-dsn');
 if(dsn !== ''){
-    Raven.config(dsn, {
-        whitelistUrls: [
-            /[-a-zA-Z0-9]*\.dsd\.io/,
-            'jenkins.local.dsd.io'
-        ]
-    }).install();
+    Raven.config(dsn).install();
 }

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -236,9 +236,9 @@ SESSION_SECURITY_PASSIVE_URLS = []
 SESSION_SECURITY_PASSIVE_HEADER = "HTTP__PASSIVE"
 SESSION_SECURITY_PASSIVE_QUERYSTRING = "_passive"
 
-if "SENTRY_DSN" in os.environ:
+if "SENTRY_PUBLIC_DSN" in os.environ:
     sentry_sdk.init(
-        dsn=os.environ.get("SENTRY_DSN"),
+        dsn=os.environ.get("SENTRY_PUBLIC_DSN"),
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
         environment=os.environ.get("CLA_ENV", "unknown"),

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -93,7 +93,7 @@ STATIC_URL = "/static/"
 ANALYTICS_ID = os.environ.get("GA_ID", "")
 ANALYTICS_DOMAIN = os.environ.get("GA_DOMAIN", "")
 
-CSP_DEFAULT_SRC = ("'self'", "cdn.ravenjs.com", "app.getsentry.com", "ws:", "wss:", "www.google-analytics.com")
+CSP_DEFAULT_SRC = ("'self'", "o345774.ingest.sentry.io", "ws:", "wss:", "www.google-analytics.com")
 
 CSP_FONT_SRC = ("'self'", "data:")
 
@@ -243,7 +243,7 @@ if "SENTRY_DSN" in os.environ:
         traces_sample_rate=1.0,
         environment=os.environ.get("CLA_ENV", "unknown"),
     )
-
+SENTRY_PUBLIC_DSN = os.environ.get("SENTRY_PUBLIC_DSN", "")
 SOCKETIO_SERVER_URL = os.environ.get("SOCKETIO_SERVER_URL", "http://localhost:8005/socket.io")
 SITE_HOSTNAME = os.environ.get("SITE_HOSTNAME", "localhost")
 

--- a/cla_frontend/templates/base.html
+++ b/cla_frontend/templates/base.html
@@ -4,7 +4,7 @@
   data-analytics-id="{{ analytics_id }}"
   data-analytics-domain="{{ analytics_domain }}">
 
-  <head data-socketio-server="{{ socketio_server_url }}">
+  <head data-sentry-dsn="{{ sentry_public_dsn }}" data-socketio-server="{{ socketio_server_url }}">
     <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -132,6 +132,8 @@
     <script src="{% static 'javascripts/vendor/vanilla-js.js' %}"></script>
     <script src="{% staticmin 'javascripts/cla.main.js' %}"></script>
     <script src="{% static 'javascripts/vendor/analytics.js' %}"></script>
+    <script src="{% static 'javascripts/vendor/raven.js' %}"></script>
+    <script type="text/javascript" src="{% static 'javascripts/vendor/raven.config.js' %}"></script>
     {% if debug %}
     <script src="{% static 'javascripts/vendor/postal.diagnostics.js' %}"></script>
     {% endif %}

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -28,7 +28,7 @@
   // vendor scripts
   paths.vendor_static.push(paths.src + 'javascripts/vendor/**/*');
   paths.vendor_static.push(paths.src + 'vendor/fullcalendar/fullcalendar.min.js');
-  paths.vendor_static.push(paths.src + 'vendor/raven-js/dist/raven.min.js');
+  paths.vendor_static.push(paths.src + 'vendor/raven-js/dist/angular/raven.js');
   // ignore certain vendor scripts from the copy
   paths.vendor_static.push('!' + paths.src + 'javascripts/vendor/diff-match-patch/');
   paths.vendor_static.push('!' + paths.src + 'javascripts/vendor/diff-match-patch/**');

--- a/tests/angular-js/karma.conf.js
+++ b/tests/angular-js/karma.conf.js
@@ -7,6 +7,7 @@
       basePath : '../../',
 
       files : [
+        'cla_frontend/assets-src/vendor/raven-js/dist/angular/raven.js',
         'cla_frontend/assets/javascripts/lib.min.js',
         'cla_frontend/assets/javascripts/cla.main.min.js',
         'cla_frontend/assets-src/vendor/angular-mocks/angular-mocks.js',

--- a/tests/angular-js/unit/AlternativeHelpServiceSpec.js
+++ b/tests/angular-js/unit/AlternativeHelpServiceSpec.js
@@ -5,6 +5,7 @@
   describe('AlternativeHelpService', function() {
 
     beforeEach(module('cla.operatorApp'));
+    angular.module('ngRaven', [])
 
     var scope, AlternativeHelpService;
 


### PR DESCRIPTION
## What does this pull request do?

- Add sentry integration with the Angular frontend
- Renamed SENTRY_DSN environment variable to SENTRY_PUBLIC_DSN
- Requires https://github.com/ministryofjustice/cla_frontend-deploy/pull/124

## Any other changes that would benefit highlighting?
I decided to introduce a new sentry environment variable instead of reusing the existing one because I felt that it needed to be explicit that this value will be public(even though we were using a public value before), so if someone changed SENTRY_DSN to a private value then it wouldn't be shared on the frontend.

After conversation with @exonian we decided to just have the SENTRY_PUBLIC_DSN and remove the existing SENTRY_DSN. At a later point, if someone wishes to use a private DSN value, they should introduce SENTRY_PRIVATE_DSN environment variable. See https://github.com/ministryofjustice/cla_frontend-deploy/pull/124#issuecomment-780514815 for further clarity.

I had to mock the NgRaven module in tests/angular-js/unit/AlternativeHelpServiceSpec.js so that it doesn't trigger or fail or angular unit tests

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
