### PR TITLE
LGA-1630 Push to dockerhub instead of dsd docker registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ jobs:
             docker login \
               --username $DOCKER_HUB_USERNAME \
               --password $DOCKER_HUB_PASSWORD \
-              --email "$DOCKER_HUB_EMAIL" \
-              $DOCKER_HUB_REGISTRY
+              --email "$DOCKER_HUB_EMAIL"
       - run:
           name: Login to the ECR Docker registry
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,21 +4,21 @@ jobs:
     docker:
       - image: docker:17.03-git
     environment:
-      DSD_DOCKER_REGISTRY: "registry.service.dsd.io"
-      DSD_DOCKER_IMAGE: "cla_frontend"
+      DOCKER_HUB_REGISTRY: "index.docker.io"
+      DOCKER_HUB_IMAGE: "ministryofjustice/cla_frontend"
     steps:
       - checkout
       - setup_remote_docker:
           version: 17.03.0-ce
           docker_layer_caching: true
       - run:
-          name: Login to the DSD Docker registry
+          name: Login to the Dockerhub registry
           command: |
             docker login \
-              --username $DOCKER_USERNAME \
-              --password $DOCKER_PASSWORD \
-              --email "${DOCKER_USERNAME}@digital.justice.gov.uk" \
-              $DSD_DOCKER_REGISTRY
+              --username $DOCKER_HUB_USERNAME \
+              --password $DOCKER_HUB_PASSWORD \
+              --email "$DOCKER_HUB_EMAIL" \
+              $DOCKER_HUB_REGISTRY
       - run:
           name: Login to the ECR Docker registry
           command: |

--- a/.circleci/tag_and_push_docker_image
+++ b/.circleci/tag_and_push_docker_image
@@ -8,16 +8,14 @@ function tag_and_push() {
   echo
   echo "Tagging and pushing $tag..."
   docker tag $built_tag $tag
-  # Multiple push attempts to work around DSD registry 504 timeouts:
-  # https://github.com/ministryofjustice/cloud-platform/issues/572
-  docker push $tag || docker push $tag || docker push $tag
+  docker push $tag
 }
 
 if [ "$CIRCLE_BRANCH" == "master" ]; then
   tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$CIRCLE_SHA1"
-  tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$CIRCLE_SHA1"
-  tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.$short_sha"
+  tag_and_push "$DOCKER_HUB_REGISTRY/$DOCKER_HUB_IMAGE:$CIRCLE_SHA1"
+  tag_and_push "$DOCKER_HUB_REGISTRY/$DOCKER_HUB_IMAGE:$safe_git_branch.$short_sha"
 fi
 tag_and_push "$ECR_DOCKER_REGISTRY/$ECR_DOCKER_IMAGE:$safe_git_branch"
 tag_and_push "$ECR_DEPLOY_IMAGE"
-tag_and_push "$DSD_DOCKER_REGISTRY/$DSD_DOCKER_IMAGE:$safe_git_branch.latest"
+tag_and_push "$DOCKER_HUB_REGISTRY/$DOCKER_HUB_IMAGE:$safe_git_branch.latest"


### PR DESCRIPTION
## What does this pull request do?

Push to dockerhub instead of dsd docker registry
Remove specifying docker hub repoistory when doing docker login

## Any other changes that would benefit highlighting?

The `$DOCKER_HUB_REGISTRY` had to be removed from the `docker login` otherwise the push was failing with: `dockerhub denied: requested access to the resource is denied`

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
