### PR TITLE
Check if Sentry is setup before require angular dependency

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -114,7 +114,7 @@
     tabWarningEnabled: false
   });
 
-  angular.module('cla.operatorApp',
+  var operatorApp = angular.module('cla.operatorApp',
     [
       'cla.settings.operator',
       'cla.states.operator',
@@ -145,12 +145,13 @@
       'diff-match-patch',
       'angularUtils.directives.dirPagination',
       'ngTextTruncate',
-      'ngIdle',
-      'ngRaven'
+      'ngIdle'
     ])
     .config(common_config)
     .run(common_run);
-
+    if (typeof Raven != "undefined" && Raven.isSetup()) {
+      operatorApp.requires.push("ngRaven");
+    }
 
   //
   // Provider App
@@ -170,7 +171,7 @@
     tabWarningEnabled: false
   });
 
-  angular.module('cla.providerApp',
+  var providerApp = angular.module('cla.providerApp',
     [
       'cla.settings.provider',
       'cla.states.provider',
@@ -201,9 +202,11 @@
       'diff-match-patch',
       'angularUtils.directives.dirPagination',
       'ngTextTruncate',
-      'ngIdle',
-      'ngRaven'
+      'ngIdle'
     ])
     .config(common_config)
     .run(common_run);
+    if (typeof Raven != "undefined" && Raven.isSetup()) {
+      providerApp.requires.push("ngRaven");
+    }
 })();


### PR DESCRIPTION
## What does this pull request do?

Check if Sentry is setup before require angular dependency

## Any other changes that would benefit highlighting?

Currently on local development were sentry is not setup, angular throws an exception that `ngRaven` module is not defined which breaks the frontend app(no further javascript is executed)

This PR checks if Raven/Sentry has been setup before requiring the `ngRaven` angular module

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
