### PR TITLE
LGA-1663 - Add env vars from secrets

### DIFF
--- a/helm_deploy/cla-frontend/templates/_helpers.tpl
+++ b/helm_deploy/cla-frontend/templates/_helpers.tpl
@@ -58,8 +58,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $environment := .Values.environment -}}
 - name: ALLOWED_HOSTS
   value: "{{ .Values.host }}"
-- name:  CLA_ENV
+- name: CLA_ENV
   value: "{{ $environment }}"
+- name: SITE_HOSTNAME
+  value: "{{ .Values.host }}"
+{{/* TODO Might be removable */}}
+- name: HOST_NAME
+  value: "{{ .Values.host }}"
 {{ range $name, $data := .Values.envVars }}
 - name: {{ $name }}
 {{- if $data.value }}

--- a/helm_deploy/cla-frontend/values-staging.yaml
+++ b/helm_deploy/cla-frontend/values-staging.yaml
@@ -6,3 +6,7 @@ environment: "staging"
 envVars:
   BACKEND_BASE_URI:
     value: "https://laa-cla-backend-uat.apps.live-1.cloud-platform.service.justice.gov.uk"
+  GA_ID:
+    value: UA-37377084-24
+  GA_DOMAIN:
+    value: dsd.io  # TODO

--- a/helm_deploy/cla-frontend/values.yaml
+++ b/helm_deploy/cla-frontend/values.yaml
@@ -91,23 +91,23 @@ envVars:
   CALL_CENTRE_CLIENT_ID:
     secret:
       name: call-centre
-      key: client-id
+      key: client_id
   CALL_CENTRE_SECRET_ID:
     secret:
       name: call-centre
-      key: secret-id
+      key: secret_id
   CLA_PROVIDER_CLIENT_ID:
     secret:
       name: cla-provider
-      key: client-id
+      key: client_id
   CLA_PROVIDER_SECRET_ID:  # This is a key change from TD, so make sure settings/base.py uses the right name
     secret:
       name: cla-provider
-      key: secret-id
+      key: secret_id
   OS_PLACES_API_KEY:
     secret:
       name: os-places
-      key: api-key
+      key: api_key
   SENTRY_PUBLIC_DSN:
     secret:
       name: sentry

--- a/helm_deploy/cla-frontend/values.yaml
+++ b/helm_deploy/cla-frontend/values.yaml
@@ -86,3 +86,37 @@ envVars:
       key: value
   DEBUG:
     value: "False"
+  SOCKETIO_SERVER_URL:
+    value: "/socket.io"
+  CALL_CENTRE_CLIENT_ID:
+    secret:
+      name: call-centre
+      key: client-id
+  CALL_CENTRE_SECRET_ID:
+    secret:
+      name: call-centre
+      key: secret-id
+  CLA_PROVIDER_CLIENT_ID:
+    secret:
+      name: cla-provider
+      key: client-id
+  CLA_PROVIDER_SECRET_ID:  # This is a key change from TD, so make sure settings/base.py uses the right name
+    secret:
+      name: cla-provider
+      key: secret-id
+  OS_PLACES_API_KEY:
+    secret:
+      name: os-places
+      key: api-key
+  SENTRY_PUBLIC_DSN:
+    secret:
+      name: sentry
+      key: dsn
+  ZENDESK_API_TOKEN:
+    secret:
+      name: zendesk-api
+      key: token
+  ZENDESK_API_USERNAME:
+    secret:
+      name: zendesk-api
+      key: username


### PR DESCRIPTION
## What does this pull request do?
Ports any required variables from cla_frontend-deploy's pillar secrets to our Helm chart
Most are instructed to use secrets, and have been added in `values.yaml`
Those which need `Values.host` are in the helpers file
Those which are not secret, but differ by env, are in `values-staging.yaml`, and an equivalent change will be required in each other env

## Any other changes that would benefit highlighting?
The secrets have been uploaded to k8s separately, outside of code

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
