### PR TITLE
LGA-1642 logging to kibana

### DIFF
--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -215,18 +215,13 @@ LOGGING = {
         "simple": {"format": "%(levelname)s %(message)s"},
         "logstash": {"()": "logstash_formatter.LogstashFormatter"},
     },
-    "filters": {
-        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
-        "require_debug_true": {"()": "django.utils.log.RequireDebugTrue"},
-    },
     "handlers": {
-        "mail_admins": {
-            "level": "ERROR",
-            "filters": ["require_debug_false"],
-            "class": "django.utils.log.AdminEmailHandler",
-        }
+        "console": {"level": "INFO", "class": "logging.StreamHandler", "formatter": "simple", "stream": sys.stdout}
     },
-    "loggers": {"django.request": {"handlers": ["mail_admins"], "level": "ERROR", "propagate": True}},
+    "loggers": {
+        "": {"handlers": ["console"], "level": "ERROR", "propagate": False},
+        "django.request": {"handlers": ["console"], "level": "ERROR", "propagate": False},
+    },
 }
 
 BACKEND_BASE_URI = os.environ.get("BACKEND_BASE_URI", "http://127.0.0.1:8000")

--- a/cla_frontend/settings/docker.py
+++ b/cla_frontend/settings/docker.py
@@ -45,6 +45,17 @@ ZONE_PROFILES = {
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.CachedStaticFilesStorage"
 
 # LOGGING CONFIG FOR DOCKER ENV
+LOGGING["filters"] = {
+    "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
+    "require_debug_true": {"()": "django.utils.log.RequireDebugTrue"},
+}
+
+LOGGING["handlers"]["mail_admins"] = {
+    "level": "ERROR",
+    "class": "django.utils.log.AdminEmailHandler",
+    "filters": ["require_debug_false"],
+}
+
 LOGGING["handlers"]["production_file"] = {
     "level": "INFO",
     "class": "logging.handlers.RotatingFileHandler",

--- a/cla_frontend/settings/docker.py
+++ b/cla_frontend/settings/docker.py
@@ -77,3 +77,4 @@ LOGGING["handlers"]["debug_file"] = {
 }
 
 LOGGING["loggers"][""] = {"handlers": ["production_file", "debug_file"], "level": "DEBUG"}
+LOGGING["loggers"]["django.request"] = {"handlers": ["mail_admins"], "level": "ERROR", "propagate": True}


### PR DESCRIPTION
## What does this pull request do?

- Sends django.request and root loggers to the stdout

- Moved "mail_admin" logging handler to settings/docker.py as template deploy still needs that logger handler (we no longer need it because we are sending our logs to the stdout)

- Moved the `require_debug_false` and `require_debug_true` logging filters to settings/docker.py as some template deploy logging handlers still need those filters.

## Any other changes that would benefit highlighting?


## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
