### PR TITLE
LGA-1612- Get js path for probe from staticfiles

### DIFF
--- a/cla_frontend/apps/status/smoketests/basic.py
+++ b/cla_frontend/apps/status/smoketests/basic.py
@@ -8,6 +8,7 @@ from urllib2 import Request, URLError, urlopen
 from urlparse import urlparse, urlunparse
 
 from django.conf import settings
+from django.contrib.staticfiles.templatetags.staticfiles import static
 
 import websocket
 
@@ -24,7 +25,7 @@ def things_exist():
 @live_smoketests.register(2, "Angular is loaded")
 @ready_smoketests.register(2, "Angular is loaded")
 def angular_loaded():
-    response = get_fe("/static/javascripts/cla.main.js")
+    response = get(static("javascripts/cla.main.js"))
     assert_status(response, 200)
 
 


### PR DESCRIPTION
## What does this pull request do?
Fixes the /ready/ probe that checks that our js file is being served
This was still looking for it to be being served by the pod at /static/, which is not the case with s3

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
