### PR TITLE
Remove ECR login from legacy build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,6 @@ jobs:
               --password $DOCKER_HUB_PASSWORD \
               --email "$DOCKER_HUB_EMAIL"
       - run:
-          name: Login to the ECR Docker registry
-          command: |
-            apk add --no-cache --no-progress py2-pip
-            pip install awscli
-            ecr_login="$(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)"
-            ${ecr_login}
-      - run:
           name: Build Docker image
           command: |
             docker build --tag application:$CIRCLE_SHA1 \


### PR DESCRIPTION
## What does this pull request do?
Removes the ECR login step from the build_for_template_deploy job
It got broken by some changes to env var names. We could probably recreate the env vars it needs, but it shouldn't be in that job anyway (template deploy only uses dockerhub, and the k8s deploys use different build jobs)

## Any other changes that would benefit highlighting?
Cherry-picked from a feature branch so that other branches can use it now

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
