### PR TITLE
LGA-1629 - Update cla_common to latest version to pull in address lookup changes

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-widget-tweaks==1.3
 slumber==0.6.2
 python-dateutil==2.4.0
 
-git+git://github.com/ministryofjustice/cla_common.git@0.3.10#egg=cla_common
+git+git://github.com/ministryofjustice/cla_common.git@0.3.14#egg=cla_common
 
 django-proxy==1.0.2
 django-csp==2.0.3


### PR DESCRIPTION
## Requires https://github.com/ministryofjustice/cla_frontend-deploy/pull/128 be merged in and deployed at the same time

## What does this pull request do?

Update cla_common to latest version to pull in address lookup changes

## Any other changes that would benefit highlighting?

Requires https://github.com/ministryofjustice/cla_frontend-deploy/pull/127 for testing

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
