### PR TITLE
LGA-1671 Update staging and training ingresses to use custom domain

### DIFF
--- a/helm_deploy/cla-frontend/values-production.yaml
+++ b/helm_deploy/cla-frontend/values-production.yaml
@@ -5,6 +5,7 @@
 replicaCount: 2
 environment: "prod"
 
+secretName: ~ # TODO: Remove this line as part of live switch-over as we are not using a custom production domain yet
 ingress:
   whitelist: []
 

--- a/helm_deploy/cla-frontend/values-uat.yaml
+++ b/helm_deploy/cla-frontend/values-uat.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 environment: "uat"
-
+secretName: ~
 envVars:
   BACKEND_BASE_URI:
     value: "https://laa-cla-backend-uat.apps.live-1.cloud-platform.service.justice.gov.uk"

--- a/helm_deploy/cla-frontend/values.yaml
+++ b/helm_deploy/cla-frontend/values.yaml
@@ -28,6 +28,7 @@ socketServer:
 
 host: 'localhost'
 
+secretName: tls-certificate
 ingress:
   enabled: true
   annotations: {}


### PR DESCRIPTION
## What does this pull request do?

Update staging and training ingresses to use custom domain

## Any other changes that would benefit highlighting?

Before merging this PR in the following environment variables must to be created in the laa-cla-frontend circleci context:
- STAGING_HOST=staging.cases.civillegaladvice.service.gov.uk
- TRAINING_HOST=training.cases.civillegaladvice.service.gov.uk

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
