### PR TITLE
LGA-1719 - Update to latest cla_common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-widget-tweaks==1.3
 slumber==0.6.2
 python-dateutil==2.4.0
 
-git+git://github.com/ministryofjustice/cla_common.git@0.3.14#egg=cla_common
+git+git://github.com/ministryofjustice/cla_common.git@0.3.15#egg=cla_common
 
 django-proxy==1.0.2
 django-csp==2.0.3


### PR DESCRIPTION
## What does this pull request do?

The new version facilitates a fix in cla_backend (timezone-aware calculation
of the assigned_out_of_hours field).
The change should not change anything for this repo, as the new
behaviour defaults to the old behaviour unless specified

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
