### PR TITLE
LGA-1729 - Remove whitelists for training and production environments

### DIFF
--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -9,7 +9,6 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
   --values ${HELM_DIR}/values-production.yaml \
   --set host=$RELEASE_HOST \
-  --set secretName=tls-certificate \
   --set image.repository=$ECR_URL_APP \
   --set image.tag=$IMAGE_TAG \
   --set socketServer.image.repository=$ECR_URL_SOCKET_SERVER \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -9,7 +9,6 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
   --set host=$RELEASE_HOST \
-  --set secretName=tls-certificate \
   --set image.repository=$ECR_URL_APP \
   --set image.tag=$IMAGE_TAG \
   --set socketServer.image.repository=$ECR_URL_SOCKET_SERVER \

--- a/bin/training_deploy.sh
+++ b/bin/training_deploy.sh
@@ -9,7 +9,6 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_TRAINING_NAMESPACE} \
   --values ${HELM_DIR}/values-training.yaml \
   --set host=$RELEASE_HOST \
-  --set secretName=tls-certificate \
   --set image.repository=$ECR_URL_APP \
   --set image.tag=$IMAGE_TAG \
   --set socketServer.image.repository=$ECR_URL_SOCKET_SERVER \

--- a/helm_deploy/cla-frontend/templates/ingress.yaml
+++ b/helm_deploy/cla-frontend/templates/ingress.yaml
@@ -9,7 +9,9 @@ metadata:
   labels:
     {{- include "cla-frontend.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.ingress.whitelist }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ include "cla-frontend.whitelist" . }}"
+    {{- end }}
     nginx.ingress.kubernetes.io/server-snippets: |
       location /socket.io {
         proxy_http_version 1.1;

--- a/helm_deploy/cla-frontend/values-production.yaml
+++ b/helm_deploy/cla-frontend/values-production.yaml
@@ -6,8 +6,10 @@ replicaCount: 2
 environment: "prod"
 
 secretName: ~ # TODO: Remove this line as part of live switch-over as we are not using a custom production domain yet
-ingress:
-  whitelist: []
+
+# TODO: Uncomment the following when app is ready for production
+#ingress:
+#  whitelist: []
 
 envVars:
   BACKEND_BASE_URI:

--- a/helm_deploy/cla-frontend/values-training.yaml
+++ b/helm_deploy/cla-frontend/values-training.yaml
@@ -3,6 +3,9 @@
 # Declare variables to be passed into your templates.
 environment: "training"
 
+ingress:
+  whitelist: []
+
 envVars:
   BACKEND_BASE_URI:
     value: "https://training.fox.civillegaladvice.service.gov.uk"

--- a/helm_deploy/cla-frontend/values-uat.yaml
+++ b/helm_deploy/cla-frontend/values-uat.yaml
@@ -4,6 +4,7 @@
 
 environment: "uat"
 secretName: ~
+
 envVars:
   BACKEND_BASE_URI:
     value: "https://laa-cla-backend-uat.apps.live-1.cloud-platform.service.justice.gov.uk"


### PR DESCRIPTION
## What does this pull request do?

- Remove whitelists for training and production environments
- Remove setting of tls certificate in deployment files as it is set in values.yaml
## Any other changes that would benefit highlighting?

Wrapping the ingress annotation`nginx.ingress.kubernetes.io/whitelist-source-range` in an if condition that checks the if whitelist is not empty is required because a `nginx.ingress.kubernetes.io/whitelist-source-range` annotation with an empty value will result ingress failing and returning a 503 for all requests.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
