### PR TITLE
LGA-1742 - Read current production host name from $CLOUD_PLATFORM_PRODUCTION_HOST environment variable

### DIFF
--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -10,7 +10,7 @@ export IMAGE_TAG="$safe_git_branch.$short_sha"
 
 case $NAMESPACE in
   production)
-      export NAMESPACE_HOST="${PRODUCTION_HOST}"
+      export NAMESPACE_HOST="${CLOUD_PLATFORM_PRODUCTION_HOST}"
       ;;
   uat)
       export NAMESPACE_HOST="${UAT_HOST}"


### PR DESCRIPTION
## What does this pull request do?

Read current production host name from $CLOUD_PLATFORM_PRODUCTION_HOST environment variable

## Any other changes that would benefit highlighting?

Current kubernetes production host name is laa-cla-frontend-production.cloud-platform.service.justice.gov.uk this PR updates the host environment variable to reflect that.

A separate PR will be raised to changed the environment variable to $PRODUCTION_HOST as part of the final switch over

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
