### PR TITLE
LGA-1742 - Update kubernetes production to use cases.civillegaladvice.service.gov.uk as the ingress host name

### DIFF
--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -10,7 +10,7 @@ export IMAGE_TAG="$safe_git_branch.$short_sha"
 
 case $NAMESPACE in
   production)
-      export NAMESPACE_HOST="${CLOUD_PLATFORM_PRODUCTION_HOST}"
+      export NAMESPACE_HOST="${PRODUCTION_HOST}"
       ;;
   uat)
       export NAMESPACE_HOST="${UAT_HOST}"

--- a/helm_deploy/cla-frontend/values-production.yaml
+++ b/helm_deploy/cla-frontend/values-production.yaml
@@ -5,7 +5,6 @@
 replicaCount: 2
 environment: "prod"
 
-secretName: ~ # TODO: Remove this line as part of live switch-over as we are not using a custom production domain yet
 
 # TODO: Uncomment the following when app is ready for production
 #ingress:


### PR DESCRIPTION
## What does this pull request do?

- Update kubernetes production to use cases.civillegaladvice.service.gov.uk as the ingress host name
- Use the secretName defined in the deploy files

## Any other changes that would benefit highlighting?

When this PR is merged the production ingress will use the hostname cases.civillegaladvice.service.gov.uk

### DO NOT MERGE BEFORE SWITCH OVER 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
