### PR TITLE
Use custom domain for staging backend instead of cloud platforms domain

### DIFF
--- a/helm_deploy/cla-frontend/values-staging.yaml
+++ b/helm_deploy/cla-frontend/values-staging.yaml
@@ -5,7 +5,7 @@ environment: "staging"
 
 envVars:
   BACKEND_BASE_URI:
-    value: "https://laa-cla-backend-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
+    value: "https://staging.fox.civillegaladvice.service.gov.uk"
   GA_ID:
     value: UA-37377084-24
   GA_DOMAIN:


### PR DESCRIPTION
## What does this pull request do?

Use custom domain for staging backend instead of cloud platforms domain

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
