### PR TITLE
LGA-1754 CHS family routing

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/services/models.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/models.js
@@ -316,7 +316,7 @@
       resource.prototype.isInScopeUnknown = function() {
         return (this.state === undefined || this.state === DIAGNOSIS_SCOPE.UNKNOWN);
       };
-      resource.prototype.nonCLACategory = function(){
+      resource.prototype.isNonCLACategory = function(){
         return this.category === 'family' && window.family_issue_flag;
       };
       resource.prototype.hasLetterOfProceedings = function() {

--- a/cla_frontend/assets-src/javascripts/app/js/services/models.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/models.js
@@ -316,6 +316,9 @@
       resource.prototype.isInScopeUnknown = function() {
         return (this.state === undefined || this.state === DIAGNOSIS_SCOPE.UNKNOWN);
       };
+      resource.prototype.nonCLACategory = function(){
+        return this.category === 'family';
+      };
       resource.prototype.hasLetterOfProceedings = function() {
         if (this.nodes && this.nodes.length > 1) {
           var last_node = this.nodes[this.nodes.length - 2]

--- a/cla_frontend/assets-src/javascripts/app/js/services/models.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/models.js
@@ -317,7 +317,7 @@
         return (this.state === undefined || this.state === DIAGNOSIS_SCOPE.UNKNOWN);
       };
       resource.prototype.nonCLACategory = function(){
-        return this.category === 'family';
+        return this.category === 'family' && window.family_issue_flag;
       };
       resource.prototype.hasLetterOfProceedings = function() {
         if (this.nodes && this.nodes.length > 1) {

--- a/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.assign.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.assign.js
@@ -25,7 +25,13 @@
           var deferred = $q.defer();
           var valid = AssignProviderValidation.validate({case: $case, personal_details: personal_details, adaptation_details: adaptation_details});
 
-          if (!diagnosis.isInScopeTrue() || !eligibility_check.isEligibilityTrue()) {
+          if(diagnosis.nonCLACategory()) {
+            var capitalisedCategory = diagnosis.category.substr(0, 1).toUpperCase() + diagnosis.category.substr(1);
+            deferred.reject({
+              msg: `${capitalisedCategory} is no longer a CLA category. Please assign a F2F provider`,
+              case: $case.reference
+            });
+          } else if (!diagnosis.isInScopeTrue() || !eligibility_check.isEligibilityTrue()) {
             // reject promise and handle in $stateChangeError
             deferred.reject({
               msg: 'The Case must be <strong>in scope</strong> and <strong>eligible</strong> to be assigned.',

--- a/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.assign.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.assign.js
@@ -26,9 +26,9 @@
           var valid = AssignProviderValidation.validate({case: $case, personal_details: personal_details, adaptation_details: adaptation_details});
 
           if(diagnosis.nonCLACategory()) {
-            var capitalisedCategory = diagnosis.category.substr(0, 1).toUpperCase() + diagnosis.category.substr(1);
+            var capitalisedCategory = diagnosis.category.charAt(0).toUpperCase() + diagnosis.category.substring(1);
             deferred.reject({
-              msg: `${capitalisedCategory} is no longer a CLA category. Please assign a F2F provider`,
+              msg: capitalisedCategory + 'is no longer a CLA category. Please assign a F2F provider',
               case: $case.reference
             });
           } else if (!diagnosis.isInScopeTrue() || !eligibility_check.isEligibilityTrue()) {

--- a/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.assign.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.assign.js
@@ -24,8 +24,7 @@
         CanAssign: ['AssignProviderValidation', '$q', 'diagnosis', 'eligibility_check', 'case', 'personal_details', 'adaptation_details', 'History', function (AssignProviderValidation, $q, diagnosis, eligibility_check, $case, personal_details, adaptation_details, History) {
           var deferred = $q.defer();
           var valid = AssignProviderValidation.validate({case: $case, personal_details: personal_details, adaptation_details: adaptation_details});
-
-          if(diagnosis.nonCLACategory()) {
+          if(diagnosis.isNonCLACategory()) {
             var capitalisedCategory = diagnosis.category.charAt(0).toUpperCase() + diagnosis.category.substring(1);
             deferred.reject({
               msg: capitalisedCategory + ' is no longer a CLA category. Please assign a F2F provider',

--- a/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.assign.js
+++ b/cla_frontend/assets-src/javascripts/app/js/states/call_centre/case_detail.edit.assign.js
@@ -28,7 +28,7 @@
           if(diagnosis.nonCLACategory()) {
             var capitalisedCategory = diagnosis.category.charAt(0).toUpperCase() + diagnosis.category.substring(1);
             deferred.reject({
-              msg: capitalisedCategory + 'is no longer a CLA category. Please assign a F2F provider',
+              msg: capitalisedCategory + ' is no longer a CLA category. Please assign a F2F provider',
               case: $case.reference
             });
           } else if (!diagnosis.isInScopeTrue() || !eligibility_check.isEligibilityTrue()) {

--- a/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.edit.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.edit.html
@@ -3,7 +3,7 @@
     <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.diversity'), 'is-disabled': !case.isInScopeAndEligible()}">
       <a ui-sref="case_detail.diversity" class="Tabs-tabLink" ng-class="{'Icon Icon--right Icon--solidTick Icon--green': personal_details.has_diversity}">Diversity</a>
     </li>
-    <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.assign'), 'is-disabled': !case.isInScopeAndEligible() || diagnosis.nonCLACategory()}">
+    <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.assign'), 'is-disabled': !case.isInScopeAndEligible() || diagnosis.isNonCLACategory()}">
       <a ui-sref="case_detail.assign" class="Tabs-tabLink" ng-class="{'Icon Icon--right Icon--solidTick Icon--green': case.provider}">Assign</a>
     </li>
   </span>

--- a/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.edit.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/call_centre/case_detail.edit.html
@@ -3,7 +3,7 @@
     <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.diversity'), 'is-disabled': !case.isInScopeAndEligible()}">
       <a ui-sref="case_detail.diversity" class="Tabs-tabLink" ng-class="{'Icon Icon--right Icon--solidTick Icon--green': personal_details.has_diversity}">Diversity</a>
     </li>
-    <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.assign'), 'is-disabled': !case.isInScopeAndEligible()}">
+    <li class="Tabs-tab" ng-class="{'is-active': $state.includes('case_detail.assign'), 'is-disabled': !case.isInScopeAndEligible() || diagnosis.nonCLACategory()}">
       <a ui-sref="case_detail.assign" class="Tabs-tabLink" ng-class="{'Icon Icon--right Icon--solidTick Icon--green': case.provider}">Assign</a>
     </li>
   </span>


### PR DESCRIPTION
## What does this pull request do?

- Add functionality to check if category is non cla (AKA family)
- Disables the `assign` tab if the category is family and prevents it from being accessed. Also writes a message on the banner near the of the screen (**pictured below**)
- Rebased off the [other ticket](https://github.com/ministryofjustice/cla_frontend/pull/758). The commits for this branch start from `f1bd484`

## Any other changes that would benefit highlighting?

**Error message**

Will give Rosie and Sannah a demo to find out what they think of the error message and get possible suggestions on what it could be.

<img width="1434" alt="Screenshot 2021-08-16 at 18 08 13" src="https://user-images.githubusercontent.com/64010092/129605919-5af5145c-1469-4b49-8efa-7f93ffea3dc3.png">

_Picture of message written after clicking on the `assign` tab and the category is family_

**Extra commits**

Rebased off the [other ticket](https://github.com/ministryofjustice/cla_frontend/pull/758) as it contained the `family_feature_flag` code.

**AssignProviderValidation code**

Also realised we have a service called `AssignProviderValidation`. Will be looking to make sure of this next time I work on this. 

`Update`: Decided not to use this in the end since it was for validating certain input fields have values. Now adding logic to this felt unnecessary and like I was overcomplicating things.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
