### PR TITLE
[WIP] LGA-79 Identify packages that can be moved from bower to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,16 +172,6 @@ jobs:
           key: node-v1-{{ checksum "package-lock.json" }}
           paths:
             - "./node_modules"
-      - restore_cache:
-          keys:
-            - bower-v1-{{ checksum "bower.json" }}
-      - run:
-          name: Install Bower dependencies
-          command: npm run bower
-      - save_cache:
-          key: bower-v1-{{ checksum "bower.json" }}
-          paths:
-            - "./cla_frontend/assets-src/vendor"
       - run:
           name: Bundle JavaScript
           command: npm run js

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,10 @@ RUN apk add --no-cache \
 
 WORKDIR /home/app
 
-# Install node dependencies
+# Install node and front-end dependencies
+# NPM has now replaced bower for installing front-end dependencies
 COPY package.json package-lock.json ./
 RUN npm install
-
-# Install front-end dependencies
-COPY .bowerrc bower.json ./
-RUN npm run bower
 
 # Build front-end assets
 COPY tasks/ ./tasks

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "lodash": "2.4.1",
-    "angular": "1.4.13",
     "angular-mocks": "1.4.x",
     "angular-resource": "1.4.x",
     "angular-animate": "1.4.x",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "lodash": "2.4.1",
-    "angular-mocks": "1.4.x",
     "angular-resource": "1.4.x",
     "angular-i18n": "1.2.16",
     "angular-ui-router": "0.2.10",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "lodash": "2.4.1",
     "jquery": "2.1.1",
-    "angular-ui-select2": "0.0.5",
     "postal.js": "0.10.3",
     "conduitjs": "0.3.3",
     "socket.io-client": "1.7.4",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "lodash": "2.4.1",
     "angular-mocks": "1.4.x",
     "angular-resource": "1.4.x",
-    "angular-animate": "1.4.x",
     "angular-i18n": "1.2.16",
     "angular-ui-router": "0.2.10",
     "angular-sanitize": "1.2.17",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
     "conduitjs": "0.3.3",
     "socket.io-client": "1.7.4",
     "rome": "1.2.1",
-    "angulartics": "1.6.0",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#1.4.5",
     "papaparse": "3.1.4",
     "ng-text-truncate": "lorenooliveira/ng-text-truncate#b2a3ed4eafdc4cc9a231fc763e12b728545f4cc7",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "papaparse": "3.1.4",
     "FileSaver": "eligrey/FileSaver.js#899ed116a946921223f25eaa2f54862b737c6e73",
-    "angularUtils": "michaelbromley/angularUtils#c6275a699ba580b66a02e7a922fe169ef9b6c61c",
     "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",
     "fullcalendar": "1.6.4",
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,6 @@
     "angular-ui-select2": "0.0.5",
     "postal.js": "0.10.3",
     "conduitjs": "0.3.3",
-    "angular-socket-io": "0.6.0",
     "socket.io-client": "1.7.4",
     "rome": "1.2.1",
     "angulartics": "1.6.0",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "socket.io-client": "1.7.4",
     "rome": "1.2.1",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#1.4.5",
     "papaparse": "3.1.4",

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,6 @@
     "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",
     "fullcalendar": "1.6.4",
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
-    "moment-timezone": "~0.3.1",
     "angular-sticky": "angular-sticky-plugin#^0.4.2",
     "raven-js": "3.27.2"
   },

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "lodash": "2.4.1",
     "jquery": "2.1.1",
     "postal.js": "0.10.3",
     "conduitjs": "0.3.3",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
     "jquery": "2.1.1",
     "angular-ui-select2": "0.0.5",
     "angular-messages": "1.4.13",
-    "angular-blocks": "0.1.9",
     "postal.js": "0.10.3",
     "conduitjs": "0.3.3",
     "angular-loading-bar": "0.5.1",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "postal.js": "0.10.3",
     "conduitjs": "0.3.3",
     "socket.io-client": "1.7.4",
     "rome": "1.2.1",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "lodash": "2.4.1",
-    "angular-sanitize": "1.2.17",
     "angular-moment": "0.7.1",
     "jquery": "2.1.1",
     "angular-ui-select2": "0.0.5",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "papaparse": "3.1.4",
-    "ng-text-truncate": "lorenooliveira/ng-text-truncate#b2a3ed4eafdc4cc9a231fc763e12b728545f4cc7",
     "FileSaver": "eligrey/FileSaver.js#899ed116a946921223f25eaa2f54862b737c6e73",
     "angularUtils": "michaelbromley/angularUtils#c6275a699ba580b66a02e7a922fe169ef9b6c61c",
     "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "rome": "1.2.1",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#1.4.5",
     "papaparse": "3.1.4",
     "ng-text-truncate": "lorenooliveira/ng-text-truncate#b2a3ed4eafdc4cc9a231fc763e12b728545f4cc7",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "angular-sticky": "angular-sticky-plugin#^0.4.2",
     "raven-js": "3.27.2"
   },

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,6 @@
     "rome": "1.2.1",
     "angulartics": "1.6.0",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#1.4.5",
-    "angular-local-storage": "0.1.3",
     "papaparse": "3.1.4",
     "ng-text-truncate": "lorenooliveira/ng-text-truncate#b2a3ed4eafdc4cc9a231fc763e12b728545f4cc7",
     "FileSaver": "eligrey/FileSaver.js#899ed116a946921223f25eaa2f54862b737c6e73",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "angular-hotkeys": "chieffancypants/angular-hotkeys#1.4.5",
     "papaparse": "3.1.4",
     "ng-text-truncate": "lorenooliveira/ng-text-truncate#b2a3ed4eafdc4cc9a231fc763e12b728545f4cc7",
     "FileSaver": "eligrey/FileSaver.js#899ed116a946921223f25eaa2f54862b737c6e73",

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "moment-timezone": "~0.3.1",
     "angular-sticky": "angular-sticky-plugin#^0.4.2",
-    "angulartics-google-analytics": "0.5.0",
     "raven-js": "3.27.2"
   },
   "resolutions": {

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "conduitjs": "0.3.3",
     "socket.io-client": "1.7.4",
     "rome": "1.2.1",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#1.4.5",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "papaparse": "3.1.4",
     "FileSaver": "eligrey/FileSaver.js#899ed116a946921223f25eaa2f54862b737c6e73",
-    "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",
     "fullcalendar": "1.6.4",
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "angular-sticky": "angular-sticky-plugin#^0.4.2",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "lodash": "2.4.1",
     "jquery": "2.1.1",
     "angular-ui-select2": "0.0.5",
-    "angular-messages": "1.4.13",
     "postal.js": "0.10.3",
     "conduitjs": "0.3.3",
     "angular-socket-io": "0.6.0",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "FileSaver": "eligrey/FileSaver.js#899ed116a946921223f25eaa2f54862b737c6e73",
     "fullcalendar": "1.6.4",
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "angular-sticky": "angular-sticky-plugin#^0.4.2",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "fullcalendar": "1.6.4",
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "angular-sticky": "angular-sticky-plugin#^0.4.2",
     "raven-js": "3.27.2"

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "raven-js": "3.27.2"
   },
   "resolutions": {
     "angular": "1.4.13",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
     "angular-messages": "1.4.13",
     "postal.js": "0.10.3",
     "conduitjs": "0.3.3",
-    "angular-loading-bar": "0.5.1",
     "angular-socket-io": "0.6.0",
     "socket.io-client": "1.7.4",
     "rome": "1.2.1",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "lodash": "2.4.1",
-    "angular-i18n": "1.2.16",
     "angular-ui-router": "0.2.10",
     "angular-sanitize": "1.2.17",
     "angular-moment": "0.7.1",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "lodash": "2.4.1",
-    "angular-ui-router": "0.2.10",
     "angular-sanitize": "1.2.17",
     "angular-moment": "0.7.1",
     "jquery": "2.1.1",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "angular-sticky": "angular-sticky-plugin#^0.4.2",
     "raven-js": "3.27.2"
   },
   "resolutions": {

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "lodash": "2.4.1",
-    "angular-moment": "0.7.1",
     "jquery": "2.1.1",
     "angular-ui-select2": "0.0.5",
     "angular-messages": "1.4.13",

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "lodash": "2.4.1",
-    "angular-resource": "1.4.x",
     "angular-i18n": "1.2.16",
     "angular-ui-router": "0.2.10",
     "angular-sanitize": "1.2.17",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "jquery": "2.1.1",
     "postal.js": "0.10.3",
     "conduitjs": "0.3.3",
     "socket.io-client": "1.7.4",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cla-frontend",
   "version": "0.1.0",
   "dependencies": {
-    "papaparse": "3.1.4",
     "FileSaver": "eligrey/FileSaver.js#899ed116a946921223f25eaa2f54862b737c6e73",
     "fullcalendar": "1.6.4",
     "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -88,8 +88,9 @@
       });
     }];
 
-  common_config = ['$resourceProvider', 'cfpLoadingBarProvider', '$analyticsProvider',
-    function($resourceProvider, cfpLoadingBarProvider, $analyticsProvider) {
+  common_config = ['$resourceProvider', 'cfpLoadingBarProvider', '$analyticsProvider', 'paginationTemplateProvider',
+    function($resourceProvider, cfpLoadingBarProvider, $analyticsProvider, paginationTemplateProvider) {
+      paginationTemplateProvider.setPath('directives/pagination/dirPagination.tpl.html');
       $resourceProvider.defaults.stripTrailingSlashes = false;
       cfpLoadingBarProvider.includeBar = false;
       $analyticsProvider.queryKeysBlacklist(['search']);

--- a/cla_frontend/assets-src/javascripts/vendor/analytics.js
+++ b/cla_frontend/assets-src/javascripts/vendor/analytics.js
@@ -11,6 +11,7 @@
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
     ga('create', analytics_id, analytics_domain);
+    ga('set', 'displayFeaturesTask', null);
     // non ng tracking
     if (!ngApp) {
       ga('send', 'pageview');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,9 @@
   "requires": true,
   "dependencies": {
     "@uirouter/angularjs": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@uirouter/angularjs/-/angularjs-1.0.13.tgz",
-      "integrity": "sha512-SXsJJRgOkTZrugV1KOR8RDnXHCLY+DYFYCZYsGZpVuotrsuIPNIXNjLvbiYDlRaj9vwIMksPUeLrCoM0I1v8hw==",
-      "requires": {
-        "@uirouter/core": "5.0.14"
-      }
-    },
-    "@uirouter/core": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-5.0.14.tgz",
-      "integrity": "sha512-wfNpvwmaVj4FU1QFtQRrr4xKtd79iA/O7Qf+prLCEZFFeBoKteBPxNmzsiD5lQXHhTK23WVabQ11lHsSincsjg=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@uirouter/angularjs/-/angularjs-0.2.10.tgz",
+      "integrity": "sha512-LKpfmub+r+IlNc51cRQ8rUNQ6/MJ/61fFCXEWIbLEIhxYmqKi/SzcB3LupifDIl7kKQ2fxLf0AUeZla1OogjNQ=="
     },
     "CSSselect": {
       "version": "0.4.1",
@@ -43,11 +35,15 @@
         "through": "2.3.8"
       }
     },
+    "StringScanner": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/StringScanner/-/StringScanner-0.0.3.tgz",
+      "integrity": "sha1-vwbs/ckARnEfTmF1VJJDt4zrOKo="
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-      "dev": true
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
     },
     "accepts": {
       "version": "1.3.3",
@@ -136,8 +132,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "amqplib": {
       "version": "0.5.2",
@@ -154,14 +149,14 @@
       }
     },
     "angular": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.8.tgz",
-      "integrity": "sha512-9WErZIOw1Cu1V5Yxdvxz/6YpND8ntdP71fdPpufPFJvZodZXqCjQBYrHqEoMZreO5i84O3D/Jw/vepoFt68Azw=="
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.4.13.tgz",
+      "integrity": "sha1-TTC7hrF7JX9RmisFEqAMsYys6bA="
     },
     "angular-animate": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.6.8.tgz",
-      "integrity": "sha512-zKaq9vtJ+QPV6q159mJkb6uKa3SiTe0PXj+W9WO3cDhLly8LuQHYRteAAD3/SqlS7GMq2SFlJvs7VQduPJpUQw=="
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.4.14.tgz",
+      "integrity": "sha1-7kBoyv234jACYxnsbLkgesqJgDg="
     },
     "angular-blocks": {
       "version": "0.1.15",
@@ -2351,8 +2346,8 @@
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
               "requires": {
-                "underscore": "~1.7.0",
-                "underscore.string": "~2.4.0"
+                "underscore": "1.7.0",
+                "underscore.string": "2.4.0"
               },
               "dependencies": {
                 "underscore.string": {
@@ -2372,8 +2367,8 @@
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
               "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
               "requires": {
-                "argparse": "~ 0.1.11",
-                "esprima": "~ 1.0.2"
+                "argparse": "0.1.16",
+                "esprima": "1.0.4"
               }
             }
           }
@@ -4729,75 +4724,95 @@
       }
     },
     "angular-hotkeys": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/angular-hotkeys/-/angular-hotkeys-1.7.0.tgz",
-      "integrity": "sha1-BS5rb0TfzYJEJ3mLfxDhkX6HAKE="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/angular-hotkeys/-/angular-hotkeys-1.4.5.tgz",
+      "integrity": "sha1-CL6WyBhjjtrWecW/Ahs+HLo7RlI="
     },
     "angular-i18n": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/angular-i18n/-/angular-i18n-1.6.8.tgz",
-      "integrity": "sha512-gp1s2uP6rX4HpswkFQp9RT8SE5vRcD+uc8CLAlJSdo6Yu0A/DYA9CBCFkTbnKp1ZSQPSYcsgXNRLxZiciRMNyA=="
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/angular-i18n/-/angular-i18n-1.4.14.tgz",
+      "integrity": "sha1-4Ul/FKkSMjrEWFDvQsc4kVOk8Sc="
     },
     "angular-loading-bar": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/angular-loading-bar/-/angular-loading-bar-0.9.0.tgz",
-      "integrity": "sha1-N+9Swl8QLCFuezzf0vxaXflijkU="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/angular-loading-bar/-/angular-loading-bar-0.5.1.tgz",
+      "integrity": "sha1-LI20gHMEnCowS+01uRI1+oScZwM="
     },
     "angular-local-storage": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/angular-local-storage/-/angular-local-storage-0.7.1.tgz",
-      "integrity": "sha1-+9JzB2PCn6mvVyXgGGx4BiHozdI="
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/angular-local-storage/-/angular-local-storage-0.1.3.tgz",
+      "integrity": "sha1-q+F+3yTWDDyT5KcZVvk47OimXAg="
     },
     "angular-messages": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.6.8.tgz",
-      "integrity": "sha512-t8t3RA26KLScraeeE0FF9wflYO3txs+ND1A1L3nXT73bI99WjRgesNoh6eXc6206lksP+zEvGQTG1q1VU3rafQ=="
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.4.13.tgz",
+      "integrity": "sha1-3BwQx8TgM1d93Dg22kMr18Q1C1U="
     },
     "angular-mocks": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.8.tgz",
-      "integrity": "sha512-yuP+PnUqOVh1ewIWAxBHOTowl/JNpTRFcVPKmIm+AZfQLU/jJxz4om4FgQY5udlIRLcbwPeXEx/TbamfC7Md9w=="
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.4.14.tgz",
+      "integrity": "sha1-6hLscKUidpfnlXVSOrvsDg+RaKc="
     },
     "angular-moment": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.2.0.tgz",
-      "integrity": "sha512-0jm7AfCTk/zbBuVuoz9MecMplGfTQ9Wk9JB8J4qYX9IddcETRukpbKXMy27YTL1wKwYJkRTbGMu/Pb3IXbMfyA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/angular-moment/-/angular-moment-0.7.1.tgz",
+      "integrity": "sha1-e5dM04nrxwBv9oj61uG4zSdihTs=",
       "requires": {
-        "moment": "2.20.1"
+        "moment": "2.6.0"
+      },
+      "dependencies": {
+        "moment": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.6.0.tgz",
+          "integrity": "sha1-B2W3K4Qd0hP6kZFMD2dlEicZ8GE="
+        }
       }
     },
     "angular-resource": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/angular-resource/-/angular-resource-1.6.8.tgz",
-      "integrity": "sha512-Vx97FiunDEWlrKFwaSH3O8/S7krWarWme1Tj88a58EJSD2RSGgHPvbD4YXvzZHk9yqitUr/t1f+6UzYLge5o/g=="
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/angular-resource/-/angular-resource-1.4.14.tgz",
+      "integrity": "sha1-OCpITi3OJb+7U1g+eD+D5dxb7mQ="
     },
     "angular-sanitize": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.6.8.tgz",
-      "integrity": "sha512-XUYxWgPwwT+DGIMzmMBMSwJbYt5g6yMiu5Pq2GIW9EuO+PBNhL4xAf8qU7b2HfH/PwM4VY5NpIa25EoKDdgXAA=="
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.2.32.tgz",
+      "integrity": "sha1-U0GE/vwRLA1vMJZPLCsJKgLoeCE="
     },
     "angular-socket-io": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/angular-socket-io/-/angular-socket-io-0.7.0.tgz",
-      "integrity": "sha1-eKjWCqVxlKAzC8MTfU2hCGmLl88="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/angular-socket-io/-/angular-socket-io-0.6.0.tgz",
+      "integrity": "sha1-xgYy6WGSgkK6yi1HlDOMPT3jv5o=",
+      "requires": {
+        "karma-coverage": "0.1.5"
+      }
+    },
+    "angular-sticky-plugin": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/angular-sticky-plugin/-/angular-sticky-plugin-0.4.2.tgz",
+      "integrity": "sha1-UscanWKSyus6C6LnRBcFyMP7Eb0="
     },
     "angular-ui-select2": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/angular-ui-select2/-/angular-ui-select2-0.0.5.tgz",
       "integrity": "sha1-FedkOv1pypBj1AXrO+L5XdXsh/U="
     },
+    "angular-utils-pagination": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/angular-utils-pagination/-/angular-utils-pagination-0.8.0.tgz",
+      "integrity": "sha1-9QDND/MlO3fIAL8SFb2oK1yR1ZU="
+    },
     "angular-xeditable": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/angular-xeditable/-/angular-xeditable-0.8.1.tgz",
-      "integrity": "sha512-L4AkM18NDKL1M/vumZxSfMm+IGO/tWDIDjy0tk9qo5TO4zGH4R8Z1g+IelewUPR3KvLPhkXUcZsIY+wjMnOTaw==",
-      "requires": {
-        "angular": "1.6.8"
-      }
+      "version": "github:teneightfive/angular-xeditable#f853a4b285ccf1c82fa9276f6172e86f62ba8d11"
     },
     "angulartics": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/angulartics/-/angulartics-1.5.0.tgz",
-      "integrity": "sha512-cO8hoSxlrWN2nxoys0vRxIEu/IT7eTFw4ODfUAeE8qq5cuIiP00lcvF/hOvUQAh8Gy/Nj9lvCzoc+f9+bBAeFg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/angulartics/-/angulartics-1.6.0.tgz",
+      "integrity": "sha512-fywhCi1InawcX+rpLv9NQ32Ed87KoZeH20SUIsRUz9dYJSxuk4/uxiKiopITveGxTC8THYHFEATj9Y/X+BvMqA=="
+    },
+    "angulartics-google-analytics": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/angulartics-google-analytics/-/angulartics-google-analytics-0.5.0.tgz",
+      "integrity": "sha512-5kj0WjwbY/tPX5igzBIQm0DhVS+2Dud52UGbC9T/+X1ZvmhwtV7zuc8m7+KwixFra3iq5csVjK23gr3k83/lpg=="
     },
     "ansi-colors": {
       "version": "1.1.0",
@@ -5073,8 +5088,7 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-map": {
       "version": "0.0.0",
@@ -5118,7 +5132,8 @@
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+      "dev": true
     },
     "asn1.js": {
       "version": "4.9.2",
@@ -5183,7 +5198,16 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.21"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "async-each": {
@@ -5208,18 +5232,14 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "atoa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
-      "integrity": "sha1-DMDpGkgOc4+SPrwQNnZHF3mzSkk="
     },
     "atob": {
       "version": "2.0.3",
@@ -5806,6 +5826,63 @@
           "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
           "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
           "dev": true
+        },
+        "engine.io-client": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
+          "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "component-inherit": "0.0.3",
+            "debug": "3.1.0",
+            "engine.io-parser": "2.1.2",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "3.3.3",
+            "xmlhttprequest-ssl": "1.5.5",
+            "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "socket.io-client": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
+          "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "2.6.9",
+            "engine.io-client": "3.1.6",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "3.1.2",
+            "to-array": "0.1.4"
+          }
+        },
+        "xmlhttprequest-ssl": {
+          "version": "1.5.5",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+          "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+          "dev": true
         }
       }
     },
@@ -6214,24 +6291,13 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
-    },
-    "bullseye": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/bullseye/-/bullseye-1.4.6.tgz",
-      "integrity": "sha1-tz9gb3tCc76ArGWs11KV1iYG/iQ=",
-      "requires": {
-        "crossvent": "1.5.0",
-        "seleccion": "2.0.0",
-        "sell": "1.0.0"
-      }
     },
     "bytes": {
       "version": "3.0.0",
@@ -6276,14 +6342,12 @@
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-      "dev": true
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
       "requires": {
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
@@ -6600,6 +6664,45 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "coffee-script-redux": {
+      "version": "git+https://github.com/michaelficarra/CoffeeScriptRedux.git#9895cd1641fdf3a2424e662ab7583726bb0e35b3",
+      "requires": {
+        "StringScanner": "0.0.3",
+        "cscodegen": "git://github.com/michaelficarra/cscodegen.git#73fd7202ac086c26f18c9d56f025b18b3c6f5383",
+        "escodegen": "0.0.28",
+        "esmangle": "0.0.17",
+        "jedediah": "0.1.1",
+        "source-map": "0.1.43"
+      },
+      "dependencies": {
+        "escodegen": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+          "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
+          "optional": true,
+          "requires": {
+            "esprima": "1.0.4",
+            "estraverse": "1.3.2",
+            "source-map": "0.1.43"
+          }
+        },
+        "estraverse": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+          "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI=",
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -6643,7 +6746,15 @@
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.21"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
       }
     },
     "combine-source-map": {
@@ -6828,14 +6939,10 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
-    "contra": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.1.tgz",
-      "integrity": "sha1-YOSYJ0s9LTMoltYPgpAK76LsrIw=",
-      "requires": {
-        "atoa": "1.0.0",
-        "ticky": "1.0.0"
-      }
+    "contra.emitter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/contra.emitter/-/contra.emitter-1.1.2.tgz",
+      "integrity": "sha1-WgFAbZjvzJinW2hjX3BLcKmsAug="
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -6937,21 +7044,6 @@
         }
       }
     },
-    "crossvent": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.0.tgz",
-      "integrity": "sha1-N3nBJCaZ4ZQX8EFOYbFEdTpS/W0=",
-      "requires": {
-        "custom-event": "1.0.0"
-      },
-      "dependencies": {
-        "custom-event": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
-          "integrity": "sha1-LkYovhncSyFLXAJjDFlx6BFhgGI="
-        }
-      }
-    },
     "cryptiles": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
@@ -6990,6 +7082,10 @@
         "randombytes": "2.0.6",
         "randomfill": "1.0.3"
       }
+    },
+    "cscodegen": {
+      "version": "git://github.com/michaelficarra/cscodegen.git#73fd7202ac086c26f18c9d56f025b18b3c6f5383",
+      "optional": true
     },
     "css-select": {
       "version": "1.3.0-rc0",
@@ -7082,7 +7178,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
       "requires": {
         "array-find-index": "1.0.2"
       }
@@ -7139,6 +7234,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -7146,8 +7242,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -7647,9 +7742,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "defaults": {
       "version": "1.0.3",
@@ -8371,27 +8464,76 @@
       }
     },
     "engine.io-client": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.4.tgz",
-      "integrity": "sha1-T88TcLRxY70s6b4nM5ckMDUNTqE=",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.6.tgz",
+      "integrity": "sha512-6+rInQu8xU7c0fIF6RC4SRKuHVWPt8Xq0bZYS4lMrTwmhRineOlEMsU3X0zS5mHIvCgJsmpOKEX7DhihGk7j0g==",
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "2.6.9",
-        "engine.io-parser": "2.1.2",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
+        "parsejson": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "1.1.5",
+        "xmlhttprequest-ssl": "1.6.3",
         "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "arraybuffer.slice": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "engine.io-parser": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+          "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
+          "requires": {
+            "after": "0.8.2",
+            "arraybuffer.slice": "0.0.6",
+            "base64-arraybuffer": "0.1.5",
+            "blob": "0.0.4",
+            "has-binary": "0.1.7",
+            "wtf-8": "1.0.0"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        },
+        "ultron": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+        },
+        "ws": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+          "requires": {
+            "options": "0.0.6",
+            "ultron": "1.0.2"
+          }
+        }
       }
     },
     "engine.io-parser": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "dev": true,
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "0.0.7",
@@ -8416,7 +8558,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
@@ -8467,8 +8608,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
@@ -8480,8 +8619,86 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true,
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        }
+      }
+    },
+    "escope": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-1.0.3.tgz",
+      "integrity": "sha1-dZ3OhJbEJI/sLQyq9BCLzz8af10=",
+      "requires": {
+        "estraverse": "2.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
+          "integrity": "sha1-WuRpYyQ2ACBmdMyySgnhZnT83KE="
+        }
+      }
+    },
+    "esmangle": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/esmangle/-/esmangle-0.0.17.tgz",
+      "integrity": "sha1-TFyTYHzeXRJ2utOW6DYinbpo2Qw=",
+      "optional": true,
+      "requires": {
+        "escodegen": "0.0.28",
+        "escope": "1.0.3",
+        "esprima": "1.0.4",
+        "esshorten": "0.0.2",
+        "estraverse": "1.3.2",
+        "optimist": "0.6.1",
+        "source-map": "0.1.43"
+      },
+      "dependencies": {
+        "escodegen": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+          "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
+          "optional": true,
+          "requires": {
+            "esprima": "1.0.4",
+            "estraverse": "1.3.2",
+            "source-map": "0.1.43"
+          }
+        },
+        "estraverse": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+          "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+    },
+    "esshorten": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/esshorten/-/esshorten-0.0.2.tgz",
+      "integrity": "sha1-KKZS8e/UDI4if4xt59vmtWDugSk=",
+      "optional": true,
+      "requires": {
+        "escope": "1.0.3",
+        "estraverse": "1.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.2.0.tgz",
+          "integrity": "sha1-aj3IpGpdZ2blZoY5/Hgpds5WYP0=",
           "optional": true
         }
       }
@@ -8489,16 +8706,12 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -8980,9 +9193,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fd-slicer": {
       "version": "1.0.1",
@@ -9014,9 +9225,9 @@
       }
     },
     "file-saver": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.3.tgz",
-      "integrity": "sha1-zdTETTqiZOrC9o7BZbx5HDSvEjI="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.2.0.tgz",
+      "integrity": "sha1-TouJaZLZdwIqU+jc7J5KSonJmUU="
     },
     "file-type": {
       "version": "4.4.0",
@@ -9052,6 +9263,46 @@
         "filename-reserved-regex": "1.0.0",
         "strip-outer": "1.0.0",
         "trim-repeated": "1.0.0"
+      }
+    },
+    "fileset": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+      "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
+      "requires": {
+        "glob": "3.2.11",
+        "minimatch": "0.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+              "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+          "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
       }
     },
     "fill-range": {
@@ -9099,7 +9350,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
       "requires": {
         "path-exists": "2.1.0",
         "pinkie-promise": "2.0.1"
@@ -10201,11 +10451,11 @@
       }
     },
     "fullcalendar": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-3.8.1.tgz",
-      "integrity": "sha1-VACkgMMDG0pF/VOGZWs3aPaCebo=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-2.3.1.tgz",
+      "integrity": "sha1-wKxY6536czvxdX47fNq7RDaiGb8=",
       "requires": {
-        "jquery": "2.2.4",
+        "jquery": "2.1.1",
         "moment": "2.20.1"
       }
     },
@@ -10287,8 +10537,7 @@
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -11125,13 +11374,19 @@
       "integrity": "sha512-sP3NK8Y/1e58O0PH9t6s7DAr/lKDSUbIY207oWSeufM6/VclB7jJrIBcPCsyhrFTCDUl9DauePbt6VqP2vPM5w==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "minimatch": "3.0.4",
         "plugin-error": "0.1.2",
         "rcloader": "0.2.2",
         "through2": "2.0.3"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -11184,7 +11439,7 @@
       "dev": true,
       "requires": {
         "js-yaml": "3.10.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "plugin-error": "0.1.2",
         "replace-ext": "1.0.0",
         "through2": "2.0.3",
@@ -11218,6 +11473,12 @@
             "argparse": "1.0.9",
             "esprima": "4.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
         },
         "replace-ext": {
           "version": "1.0.0",
@@ -11864,13 +12125,19 @@
       "requires": {
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "make-error-cause": "1.2.2",
         "through2": "2.0.3",
         "uglify-js": "3.3.9",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11932,6 +12199,25 @@
         "glogg": "1.0.1"
       }
     },
+    "handlebars": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
+      "integrity": "sha1-GMbTRAw16RsZs/9YK5FRq0mF1Pw=",
+      "requires": {
+        "optimist": "0.3.7",
+        "uglify-js": "2.3.6"
+      },
+      "dependencies": {
+        "optimist": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -11976,10 +12262,19 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "has-binary": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "has-binary2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
       "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
+      "dev": true,
       "requires": {
         "isarray": "2.0.1"
       },
@@ -11987,7 +12282,8 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         }
       }
     },
@@ -12112,8 +12408,17 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "request": "2.83.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "hmac-drbg": {
@@ -12145,8 +12450,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -12277,6 +12581,20 @@
         "extend": "3.0.1"
       }
     },
+    "ibrik": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ibrik/-/ibrik-1.0.1.tgz",
+      "integrity": "sha1-upwM+TAsUagS3EqSA4s95XnArvs=",
+      "requires": {
+        "coffee-script-redux": "git+https://github.com/michaelficarra/CoffeeScriptRedux.git#9895cd1641fdf3a2424e662ab7583726bb0e35b3",
+        "escodegen": "1.9.0",
+        "estraverse": "4.2.0",
+        "istanbul": "0.1.46",
+        "mkdirp": "0.5.1",
+        "optimist": "0.6.1",
+        "which": "1.3.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -12375,7 +12693,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -12412,8 +12729,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -12565,8 +12881,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -12587,7 +12902,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
@@ -12670,7 +12984,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -12966,8 +13279,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-valid-glob": {
       "version": "0.3.0",
@@ -12990,8 +13302,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -13002,8 +13313,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -13016,6 +13326,69 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "istanbul": {
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.1.46.tgz",
+      "integrity": "sha1-zv6xx4fRJabbI70PY7Drk5CwtA0=",
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "0.2.10",
+        "escodegen": "0.0.23",
+        "esprima": "1.0.4",
+        "fileset": "0.1.8",
+        "handlebars": "1.0.12",
+        "mkdirp": "0.3.5",
+        "nopt": "2.1.2",
+        "resolve": "0.5.1",
+        "which": "1.0.9",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "escodegen": {
+          "version": "0.0.23",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.23.tgz",
+          "integrity": "sha1-ms+XgWQ2jkInZXHxiDnII7OoRN8=",
+          "requires": {
+            "esprima": "1.0.4",
+            "estraverse": "0.0.4",
+            "source-map": "0.5.7"
+          }
+        },
+        "estraverse": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
+          "integrity": "sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI="
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+        },
+        "nopt": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+          "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
+          "requires": {
+            "abbrev": "1.0.9"
+          }
+        },
+        "resolve": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.5.1.tgz",
+          "integrity": "sha1-FeSiIsQja81M+FRUQSwtD7ZSRXY="
+        },
+        "which": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
+        }
+      }
     },
     "jasmine": {
       "version": "3.2.0",
@@ -13077,6 +13450,11 @@
         "colors": "1.1.2"
       }
     },
+    "jedediah": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jedediah/-/jedediah-0.1.1.tgz",
+      "integrity": "sha1-UfMwIevsaEfYRMtTu8CG7jiHf4Q="
+    },
     "jpegtran-bin": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz",
@@ -13090,9 +13468,9 @@
       }
     },
     "jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.1.tgz",
+      "integrity": "sha1-go/GD1D37lmDNj706wHF9wr0vVs="
     },
     "js-base64": {
       "version": "2.4.9",
@@ -13225,6 +13603,11 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -13302,7 +13685,7 @@
         "graceful-fs": "4.1.11",
         "http-proxy": "1.16.2",
         "isbinaryfile": "3.0.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "log4js": "2.5.2",
         "mime": "1.6.0",
         "minimatch": "3.0.4",
@@ -13335,6 +13718,12 @@
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "minimatch": {
@@ -13373,6 +13762,27 @@
         "which": "1.3.0"
       }
     },
+    "karma-coverage": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.1.5.tgz",
+      "integrity": "sha1-pNy+h9SndlRWymQhi18GAQGOE3E=",
+      "requires": {
+        "dateformat": "1.0.12",
+        "ibrik": "1.0.1",
+        "istanbul": "0.1.46"
+      },
+      "dependencies": {
+        "dateformat": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "requires": {
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
+          }
+        }
+      }
+    },
     "karma-firefox-launcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",
@@ -13401,7 +13811,7 @@
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "phantomjs-prebuilt": "2.1.16"
       },
       "dependencies": {
@@ -13432,6 +13842,12 @@
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "minimist": {
@@ -13603,8 +14019,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "optional": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -13684,7 +14098,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
@@ -13696,14 +14109,12 @@
         "graceful-fs": {
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
           }
@@ -13791,9 +14202,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+      "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -13849,14 +14260,12 @@
     "lodash._isnative": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
-      "dev": true
+      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
     },
     "lodash._objecttypes": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
-      "dev": true
+      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
     },
     "lodash._reescape": {
       "version": "3.0.0",
@@ -13926,6 +14335,16 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
+      "integrity": "sha1-2M6tJG7EuSbouFZ4/Dlr/rqMxvw=",
+      "requires": {
+        "lodash.isfunction": "2.4.1",
+        "lodash.isobject": "2.4.1",
+        "lodash.now": "2.4.1"
+      }
+    },
     "lodash.defaults": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
@@ -13982,6 +14401,11 @@
       "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
       "dev": true
     },
+    "lodash.isfunction": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+      "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE="
+    },
     "lodash.isnull": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
@@ -13992,7 +14416,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "dev": true,
       "requires": {
         "lodash._objecttypes": "2.4.1"
       }
@@ -14019,6 +14442,14 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
+    },
+    "lodash.now": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
+      "integrity": "sha1-aHIVZQBSUYX6+WeFu3/n/hW1YsY=",
+      "requires": {
+        "lodash._isnative": "2.4.1"
+      }
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -14051,6 +14482,16 @@
       "requires": {
         "lodash._reinterpolate": "3.0.0",
         "lodash.escape": "3.2.0"
+      }
+    },
+    "lodash.throttle": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-2.4.1.tgz",
+      "integrity": "sha1-sP36W6SwhMR/89EF/9j8ThBRJI0=",
+      "requires": {
+        "lodash.debounce": "2.4.1",
+        "lodash.isfunction": "2.4.1",
+        "lodash.isobject": "2.4.1"
       }
     },
     "lodash.values": {
@@ -14342,7 +14783,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
       "requires": {
         "currently-unhandled": "0.4.1",
         "signal-exit": "3.0.2"
@@ -14370,8 +14810,7 @@
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "mailcomposer": {
       "version": "4.0.1",
@@ -14518,8 +14957,7 @@
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "map-stream": {
       "version": "0.0.4",
@@ -14602,7 +15040,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
       "requires": {
         "camelcase-keys": "2.1.0",
         "decamelize": "1.2.0",
@@ -14619,8 +15056,7 @@
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         }
       }
     },
@@ -14753,8 +15189,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.0",
@@ -14781,7 +15216,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -14789,8 +15223,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -14892,10 +15325,19 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
       "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
+    "moment-timezone": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
+      "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
+      "requires": {
+        "moment": "2.20.1"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "multipipe": {
       "version": "0.1.2",
@@ -15002,12 +15444,7 @@
       }
     },
     "ng-idle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/ng-idle/-/ng-idle-1.3.2.tgz",
-      "integrity": "sha1-c6TcwKbINgMQ0Tlt83a+a9CwqGc=",
-      "requires": {
-        "angular": "1.6.8"
-      }
+      "version": "github:HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3"
     },
     "ng-text-truncate": {
       "version": "1.0.0",
@@ -15407,7 +15844,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -15476,8 +15912,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -15724,7 +16159,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.10",
         "wordwrap": "0.0.3"
@@ -15733,8 +16167,7 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }
     },
@@ -15742,8 +16175,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "optional": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -15756,11 +16187,14 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true,
-          "optional": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "optipng-bin": {
       "version": "3.1.4",
@@ -15910,9 +16344,9 @@
       "dev": true
     },
     "papaparse": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.3.6.tgz",
-      "integrity": "sha1-lWbtoOyrE6/LdApiOBxpn0hssUU="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.0.0.tgz",
+      "integrity": "sha1-K/rfYL/5j1ff46GQLXxR5Q9U1OI="
     },
     "parents": {
       "version": "1.0.1",
@@ -15992,7 +16426,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -16002,6 +16435,14 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
+    },
+    "parsejson": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseqs": {
       "version": "0.0.5",
@@ -16047,7 +16488,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
       "requires": {
         "pinkie-promise": "2.0.1"
       }
@@ -16115,7 +16555,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
@@ -16125,8 +16564,7 @@
         "graceful-fs": {
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         }
       }
     },
@@ -16417,20 +16855,17 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -16579,18 +17014,24 @@
       "dev": true
     },
     "postal": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/postal/-/postal-2.0.5.tgz",
-      "integrity": "sha1-f58DWUOiTaqZY6xaU7XQzwffJLk=",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/postal/-/postal-0.10.3.tgz",
+      "integrity": "sha1-HZjCuSOVtnmFrr3ZDkLUBSzTBaY=",
       "requires": {
-        "lodash": "4.17.4"
+        "conduitjs": "0.3.3",
+        "lodash": "2.4.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.1",
+          "bundled": true
+        }
       }
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -16720,6 +17161,21 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "raf": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-2.0.4.tgz",
+      "integrity": "sha1-SZPkU+pSdb9u8HoWO9/pojIztiM=",
+      "requires": {
+        "performance-now": "0.1.4"
+      },
+      "dependencies": {
+        "performance-now": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.1.4.tgz",
+          "integrity": "sha1-NgtkLwc/+MKmk7PDjXzLwXtTGDs="
+        }
+      }
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -16765,6 +17221,11 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
+    },
+    "raven-js": {
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.2.tgz",
+      "integrity": "sha512-mFWQcXnhRFEQe5HeFroPaEghlnqy7F5E2J3Fsab189ondqUzcjwSVi7el7F36cr6PvQYXoZ1P2F5CSF2/azeMQ=="
     },
     "raw-body": {
       "version": "2.3.2",
@@ -16920,7 +17381,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
       "requires": {
         "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
@@ -16931,7 +17391,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
       "requires": {
         "find-up": "1.1.2",
         "read-pkg": "1.1.0"
@@ -17021,7 +17480,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
       "requires": {
         "indent-string": "2.1.0",
         "strip-indent": "1.0.1"
@@ -17093,7 +17551,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
@@ -17235,9 +17692,18 @@
       "optional": true,
       "requires": {
         "extend": "3.0.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "request": "2.83.0",
         "when": "3.7.8"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "require-coercible-to-string-x": {
@@ -17346,14 +17812,14 @@
       }
     },
     "rome": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/rome/-/rome-2.1.22.tgz",
-      "integrity": "sha1-S/JTGMwFIq6S3QkEcs56bgsfXgI=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rome/-/rome-1.2.1.tgz",
+      "integrity": "sha1-1+3nJhspRo1TdUOuneSqPrRwhsU=",
       "requires": {
-        "bullseye": "1.4.6",
-        "contra": "1.9.1",
-        "crossvent": "1.5.0",
-        "moment": "2.20.1"
+        "contra.emitter": "1.1.2",
+        "lodash.throttle": "2.4.1",
+        "moment": "2.20.1",
+        "raf": "2.0.4"
       }
     },
     "run-sequence": {
@@ -17376,7 +17842,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -17385,7 +17852,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.3",
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
       },
@@ -17409,6 +17876,12 @@
             "once": "1.3.3",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -17498,21 +17971,15 @@
         }
       }
     },
-    "seleccion": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/seleccion/-/seleccion-2.0.0.tgz",
-      "integrity": "sha1-CYSsHo31E+OLQaYI5lBC6DgeCnM="
-    },
-    "sell": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sell/-/sell-1.0.0.tgz",
-      "integrity": "sha1-O6yn5R943e6eIu6hrHR6Y2i9FjA="
+    "select2": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-3.5.1.tgz",
+      "integrity": "sha1-8oGUibvGX9bTKL5yu+K5XdfofP4="
     },
     "semver": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-      "dev": true
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
     },
     "semver-regex": {
       "version": "1.0.0",
@@ -17738,14 +18205,12 @@
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-fmt": {
       "version": "0.1.0",
@@ -17920,6 +18385,65 @@
         "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.0.4",
         "socket.io-parser": "3.1.2"
+      },
+      "dependencies": {
+        "engine.io-client": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
+          "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "component-inherit": "0.0.3",
+            "debug": "3.1.0",
+            "engine.io-parser": "2.1.2",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "3.3.3",
+            "xmlhttprequest-ssl": "1.5.5",
+            "yeast": "0.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "socket.io-client": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
+          "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "2.6.9",
+            "engine.io-client": "3.1.6",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "3.1.2",
+            "to-array": "0.1.4"
+          }
+        },
+        "xmlhttprequest-ssl": {
+          "version": "1.5.5",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+          "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+          "dev": true
+        }
       }
     },
     "socket.io-adapter": {
@@ -17929,29 +18453,74 @@
       "dev": true
     },
     "socket.io-client": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-      "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
+      "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
       "requires": {
         "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "engine.io-client": "3.1.4",
-        "has-cors": "1.1.0",
+        "debug": "2.3.3",
+        "engine.io-client": "1.8.6",
+        "has-binary": "0.1.7",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
-        "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.1.2",
+        "socket.io-parser": "2.3.1",
         "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        },
+        "socket.io-parser": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+          "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
+          "requires": {
+            "component-emitter": "1.1.2",
+            "debug": "2.2.0",
+            "isarray": "0.0.1",
+            "json3": "3.3.2"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+              "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+            },
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "requires": {
+                "ms": "0.7.1"
+              }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+            }
+          }
+        }
       }
     },
     "socket.io-parser": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
       "integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
+      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "debug": "2.6.9",
@@ -17962,7 +18531,8 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         }
       }
     },
@@ -17998,8 +18568,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.1",
@@ -18030,7 +18599,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -18038,14 +18606,12 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "split-string": {
       "version": "3.1.0",
@@ -18708,7 +19274,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
       "requires": {
         "get-stdin": "4.0.1"
       }
@@ -18766,10 +19331,18 @@
       "requires": {
         "argparse": "1.0.9",
         "cubic2quad": "1.1.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.21",
         "microbuffer": "1.0.0",
         "svgpath": "2.2.1",
         "xmldom": "0.1.27"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
       }
     },
     "svgicons2svgfont": {
@@ -19126,11 +19699,6 @@
       "dev": true,
       "optional": true
     },
-    "ticky": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.0.tgz",
-      "integrity": "sha1-6H847gSR6jL2Lo8FZ7qWOLKfBJw="
-    },
     "tildify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
@@ -19453,8 +20021,7 @@
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-repeated": {
       "version": "1.0.0",
@@ -19589,7 +20156,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }
@@ -19633,10 +20199,44 @@
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+      "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+      "requires": {
+        "async": "0.2.10",
+        "optimist": "0.3.7",
+        "source-map": "0.1.43"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "optimist": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
     },
     "umd": {
       "version": "3.0.1",
@@ -19971,7 +20571,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -20170,7 +20769,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -20205,8 +20803,7 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -20245,11 +20842,17 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "dev": true,
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",
         "ultron": "1.1.1"
       }
+    },
+    "wtf-8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
     },
     "xmlbuilder": {
       "version": "8.2.2",
@@ -20264,9 +20867,9 @@
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q=="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4797,9 +4797,9 @@
       "integrity": "sha1-FedkOv1pypBj1AXrO+L5XdXsh/U="
     },
     "angular-utils-pagination": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/angular-utils-pagination/-/angular-utils-pagination-0.8.0.tgz",
-      "integrity": "sha1-9QDND/MlO3fIAL8SFb2oK1yR1ZU="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/angular-utils-pagination/-/angular-utils-pagination-0.11.1.tgz",
+      "integrity": "sha1-7618iHm+swrT13cH+T49DvUfLGY="
     },
     "angular-xeditable": {
       "version": "github:teneightfive/angular-xeditable#f853a4b285ccf1c82fa9276f6172e86f62ba8d11"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15444,7 +15444,9 @@
       }
     },
     "ng-idle": {
-      "version": "github:HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ng-idle/-/ng-idle-1.0.4.tgz",
+      "integrity": "sha1-xtXetvOmP9QJMF6M/8ykMgVBEVk="
     },
     "ng-text-truncate": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "papaparse": "^4.3.6",
     "postal": "0.10.3",
     "rome": "^2.1.22",
-    "socket.io-client": "^2.0.4"
+    "socket.io-client": "1.7.4"
   },
   "devDependencies": {
     "bower": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ng-idle": "^1.3.2",
     "ng-text-truncate": "^1.0.0",
     "papaparse": "^4.3.6",
-    "postal": "^2.0.5",
+    "postal": "0.10.3",
     "rome": "^2.1.22",
     "socket.io-client": "^2.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "angular-xeditable": "^0.8.1",
     "angulartics": "1.6.0",
     "angulartics-google-analytics": "0.5.0",
-    "conduitjs": "^0.3.3",
+    "conduitjs": "0.3.3",
     "extend": "^3.0.1",
     "file-saver": "^1.3.3",
     "fullcalendar": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "angular-socket-io": "0.6.0",
     "angular-sticky-plugin": "0.4.2",
     "angular-ui-select2": "0.0.5",
-    "angular-utils-pagination": "^0.11.1",
+    "angular-utils-pagination": "0.11.1",
     "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",
     "angulartics": "1.6.0",
     "angulartics-google-analytics": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "moment-timezone": "0.4.1",
     "ng-idle": "^1.3.2",
     "ng-text-truncate": "^1.0.0",
-    "papaparse": "^4.3.6",
+    "papaparse": "4.0.0",
     "postal": "0.10.3",
     "rome": "1.2.1",
     "socket.io-client": "1.7.4"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "angular-animate": "1.4.x",
     "angular-blocks": "^0.1.15",
     "angular-hotkeys": "^1.7.0",
-    "angular-i18n": "^1.6.8",
+    "angular-i18n": "1.2.16",
     "angular-loading-bar": "^0.9.0",
     "angular-local-storage": "^0.7.1",
     "angular-messages": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ng-text-truncate": "^1.0.0",
     "papaparse": "4.0.0",
     "postal": "0.10.3",
+    "raven-js": "3.27.2",
     "rome": "1.2.1",
     "socket.io-client": "1.7.4"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "conduitjs": "0.3.3",
     "extend": "^3.0.1",
     "file-saver": "1.2.0",
-    "fullcalendar": "^3.8.1",
+    "fullcalendar": "2.3.1",
     "govuk_frontend_toolkit": "1.4.0",
     "jquery": "2.1.1",
     "lodash": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jquery": "2.1.1",
     "lodash": "2.4.1",
     "moment-timezone": "0.4.1",
-    "ng-idle": "^1.3.2",
+    "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
     "ng-text-truncate": "^1.0.0",
     "papaparse": "4.0.0",
     "postal": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "angular-socket-io": "0.6.0",
     "angular-ui-select2": "0.0.5",
     "angular-xeditable": "^0.8.1",
-    "angulartics": "^1.5.0",
+    "angulartics": "1.6.0",
     "angulartics-google-analytics": "0.5.0",
     "conduitjs": "^0.3.3",
     "extend": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "angular-sanitize": "1.2.x",
     "angular-socket-io": "0.6.0",
     "angular-ui-select2": "0.0.5",
+    "angular-utils-pagination": "0.8.0",
     "angular-xeditable": "^0.8.1",
     "angulartics": "1.6.0",
     "angulartics-google-analytics": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "angular": "1.4.13",
     "angular-animate": "1.4.x",
     "angular-blocks": "0.1.x",
-    "angular-hotkeys": "^1.7.0",
+    "angular-hotkeys": "1.4.5",
     "angular-i18n": "1.4.x",
     "angular-loading-bar": "0.5.1",
     "angular-local-storage": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ng-text-truncate": "^1.0.0",
     "papaparse": "^4.3.6",
     "postal": "0.10.3",
-    "rome": "^2.1.22",
+    "rome": "1.2.1",
     "socket.io-client": "1.7.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "postal": "0.10.3",
     "raven-js": "3.27.2",
     "rome": "1.2.1",
+    "select2": "3.5.1",
     "socket.io-client": "1.7.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "angular-resource": "1.4.x",
     "angular-sanitize": "1.2.x",
     "angular-socket-io": "0.6.0",
+    "angular-sticky-plugin": "0.4.2",
     "angular-ui-select2": "0.0.5",
     "angular-utils-pagination": "0.8.0",
     "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "govuk_frontend_toolkit": "1.4.0",
     "jquery": "2.1.1",
     "lodash": "2.4.1",
+    "moment-timezone": "0.4.1",
     "ng-idle": "^1.3.2",
     "ng-text-truncate": "^1.0.0",
     "papaparse": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "angular-animate": "1.4.x",
     "angular-blocks": "^0.1.15",
     "angular-hotkeys": "^1.7.0",
-    "angular-i18n": "1.2.16",
+    "angular-i18n": "1.4.x",
     "angular-loading-bar": "^0.9.0",
     "angular-local-storage": "^0.7.1",
     "angular-messages": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "angular-i18n": "1.4.x",
     "angular-loading-bar": "0.5.1",
     "angular-local-storage": "^0.7.1",
-    "angular-messages": "^1.6.8",
+    "angular-messages": "1.4.13",
     "angular-mocks": "1.4.x",
     "angular-moment": "0.7.1",
     "angular-resource": "1.4.x",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jquery": "2.1.1",
     "lodash": "2.4.1",
     "moment-timezone": "0.4.1",
-    "ng-idle": "HackedByChinese/ng-idle#b5c95763419498d6daaf953c79eeaf55066f4be3",
+    "ng-idle": "1.0.4",
     "ng-text-truncate": "^1.0.0",
     "papaparse": "4.0.0",
     "postal": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "angular-socket-io": "0.6.0",
     "angular-ui-select2": "0.0.5",
     "angular-utils-pagination": "0.8.0",
-    "angular-xeditable": "^0.8.1",
+    "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",
     "angulartics": "1.6.0",
     "angulartics-google-analytics": "0.5.0",
     "conduitjs": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@uirouter/angularjs": "0.2.10",
-    "angular": "1.4.3",
+    "angular": "1.4.13",
     "angular-animate": "1.4.x",
     "angular-blocks": "^0.1.15",
     "angular-hotkeys": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "angular-loading-bar": "^0.9.0",
     "angular-local-storage": "^0.7.1",
     "angular-messages": "^1.6.8",
-    "angular-mocks": "^1.6.8",
+    "angular-mocks": "1.4.x",
     "angular-moment": "^1.2.0",
     "angular-resource": "^1.6.8",
     "angular-sanitize": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash": "2.4.1",
     "moment-timezone": "0.4.1",
     "ng-idle": "1.0.4",
-    "ng-text-truncate": "^1.0.0",
+    "ng-text-truncate": "1.0.0",
     "papaparse": "4.0.0",
     "postal": "0.10.3",
     "raven-js": "3.27.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "file-saver": "^1.3.3",
     "fullcalendar": "^3.8.1",
     "govuk_frontend_toolkit": "1.4.0",
-    "jquery": "^2.2.4",
+    "jquery": "2.1.1",
     "lodash": "2.4.1",
     "ng-idle": "^1.3.2",
     "ng-text-truncate": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@uirouter/angularjs": "0.2.10",
     "angular": "1.4.13",
     "angular-animate": "1.4.x",
-    "angular-blocks": "^0.1.15",
+    "angular-blocks": "0.1.x",
     "angular-hotkeys": "^1.7.0",
     "angular-i18n": "1.4.x",
     "angular-loading-bar": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "angular-messages": "^1.6.8",
     "angular-mocks": "1.4.x",
     "angular-moment": "^1.2.0",
-    "angular-resource": "^1.6.8",
+    "angular-resource": "1.4.x",
     "angular-sanitize": "^1.6.8",
     "angular-socket-io": "^0.7.0",
     "angular-ui-select2": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "angular-moment": "0.7.1",
     "angular-resource": "1.4.x",
     "angular-sanitize": "1.2.x",
-    "angular-socket-io": "^0.7.0",
+    "angular-socket-io": "0.6.0",
     "angular-ui-select2": "0.0.5",
     "angular-xeditable": "^0.8.1",
     "angulartics": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "angular-ui-select2": "0.0.5",
     "angular-xeditable": "^0.8.1",
     "angulartics": "^1.5.0",
+    "angulartics-google-analytics": "0.5.0",
     "conduitjs": "^0.3.3",
     "extend": "^3.0.1",
     "file-saver": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@uirouter/angularjs": "^1.0.13",
-    "angular": "^1.6.8",
+    "angular": "1.4.3",
     "angular-animate": "^1.6.8",
     "angular-blocks": "^0.1.15",
     "angular-hotkeys": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "angular-socket-io": "0.6.0",
     "angular-sticky-plugin": "0.4.2",
     "angular-ui-select2": "0.0.5",
-    "angular-utils-pagination": "0.8.0",
+    "angular-utils-pagination": "^0.11.1",
     "angular-xeditable": "teneightfive/angular-xeditable#0.2.0",
     "angulartics": "1.6.0",
     "angulartics-google-analytics": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uirouter/angularjs": "^1.0.13",
     "angular": "1.4.3",
-    "angular-animate": "^1.6.8",
+    "angular-animate": "1.4.x",
     "angular-blocks": "^0.1.15",
     "angular-hotkeys": "^1.7.0",
     "angular-i18n": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "fullcalendar": "^3.8.1",
     "govuk_frontend_toolkit": "1.4.0",
     "jquery": "^2.2.4",
-    "lodash": "^4.17.4",
+    "lodash": "2.4.1",
     "ng-idle": "^1.3.2",
     "ng-text-truncate": "^1.0.0",
     "papaparse": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "angular-hotkeys": "^1.7.0",
     "angular-i18n": "1.4.x",
     "angular-loading-bar": "0.5.1",
-    "angular-local-storage": "^0.7.1",
+    "angular-local-storage": "0.1.3",
     "angular-messages": "1.4.13",
     "angular-mocks": "1.4.x",
     "angular-moment": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ministryofjustice/cla_frontend"
   },
   "dependencies": {
-    "@uirouter/angularjs": "^1.0.13",
+    "@uirouter/angularjs": "0.2.10",
     "angular": "1.4.3",
     "angular-animate": "1.4.x",
     "angular-blocks": "^0.1.15",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "angular-local-storage": "^0.7.1",
     "angular-messages": "^1.6.8",
     "angular-mocks": "1.4.x",
-    "angular-moment": "^1.2.0",
+    "angular-moment": "0.7.1",
     "angular-resource": "1.4.x",
     "angular-sanitize": "1.2.x",
     "angular-socket-io": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "angulartics": "1.6.0",
     "angulartics-google-analytics": "0.5.0",
     "conduitjs": "0.3.3",
-    "extend": "^3.0.1",
     "file-saver": "1.2.0",
     "fullcalendar": "2.3.1",
     "govuk_frontend_toolkit": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "angular-mocks": "1.4.x",
     "angular-moment": "^1.2.0",
     "angular-resource": "1.4.x",
-    "angular-sanitize": "^1.6.8",
+    "angular-sanitize": "1.2.x",
     "angular-socket-io": "^0.7.0",
     "angular-ui-select2": "0.0.5",
     "angular-xeditable": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "angulartics-google-analytics": "0.5.0",
     "conduitjs": "0.3.3",
     "extend": "^3.0.1",
-    "file-saver": "^1.3.3",
+    "file-saver": "1.2.0",
     "fullcalendar": "^3.8.1",
     "govuk_frontend_toolkit": "1.4.0",
     "jquery": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "angular-blocks": "0.1.x",
     "angular-hotkeys": "^1.7.0",
     "angular-i18n": "1.4.x",
-    "angular-loading-bar": "^0.9.0",
+    "angular-loading-bar": "0.5.1",
     "angular-local-storage": "^0.7.1",
     "angular-messages": "^1.6.8",
     "angular-mocks": "1.4.x",

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -63,7 +63,7 @@
       libPath + 'angular-loading-bar/build/loading-bar.js',
       paths.src + 'vendor/socket.io-client/dist/socket.io.js',
       libPath + 'angular-socket-io/socket.js',
-      paths.src + 'vendor/angulartics/src/angulartics.js',
+      libPath + 'angulartics/src/angulartics.js',
       libPath + 'angulartics-google-analytics/lib/angulartics-ga.js',
       paths.src + 'vendor/angular-hotkeys/build/hotkeys.js',
       paths.src + 'vendor/ng-text-truncate/ng-text-truncate.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -59,7 +59,7 @@
       paths.src + 'javascripts/vendor/ui-bootstrap-custom-tpls-1.3.3.js',
       paths.src + 'vendor/angular-xeditable/dist/js/xeditable.js',
       paths.src + 'vendor/conduitjs/lib/conduit.js',
-      paths.src + 'vendor/postal.js/lib/postal.js',
+      libPath + 'postal/lib/postal.js',
       libPath + 'angular-loading-bar/build/loading-bar.js',
       paths.src + 'vendor/socket.io-client/dist/socket.io.js',
       libPath + 'angular-socket-io/socket.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -43,7 +43,7 @@
       // angular specific
       libPath + 'angular/angular.js',
       libPath + 'angular-sanitize/angular-sanitize.js',
-      paths.src + 'vendor/angular-messages/angular-messages.js',
+      libPath + 'angular-messages/angular-messages.js',
       libPath + 'angular-animate/angular-animate.js',
       paths.src + 'vendor/angular-sticky/dist/angular-sticky.js',
       libPath + 'angular-resource/angular-resource.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -68,7 +68,7 @@
       libPath + 'angular-hotkeys/build/hotkeys.js',
       libPath + 'ng-text-truncate/ng-text-truncate.js',
       libPath + 'angular-local-storage/dist/angular-local-storage.js',
-      paths.src + 'vendor/angularUtils/src/directives/pagination/dirPagination.js',
+      libPath + 'angular-utils-pagination/dirPagination.js',
       paths.src + 'vendor/ng-idle/angular-idle.js',
       paths.src + 'javascripts/vendor/diff-match-patch/angular-diff-match-patch.js',
       paths.src + 'javascripts/vendor/diff-match-patch/google-diff-match-patch.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -53,7 +53,7 @@
       libPath + 'angular-i18n/angular-locale_en-gb.js',
       paths.src + 'vendor/moment/moment.js',
       paths.src + 'vendor/moment-timezone/builds/moment-timezone-with-data-2010-2020.js',
-      paths.src + 'vendor/angular-moment/angular-moment.js',
+      libPath + 'angular-moment/angular-moment.js',
       libPath + 'angular-blocks/dist/angular-blocks.js',
       paths.src + 'vendor/rome/dist/rome.standalone.js', // datepicker
       paths.src + 'javascripts/vendor/ui-bootstrap-custom-tpls-1.3.3.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -69,7 +69,7 @@
       libPath + 'ng-text-truncate/ng-text-truncate.js',
       libPath + 'angular-local-storage/dist/angular-local-storage.js',
       libPath + 'angular-utils-pagination/dirPagination.js',
-      paths.src + 'vendor/ng-idle/angular-idle.js',
+      libPath + 'ng-idle/angular-idle.js',
       paths.src + 'javascripts/vendor/diff-match-patch/angular-diff-match-patch.js',
       paths.src + 'javascripts/vendor/diff-match-patch/google-diff-match-patch.js',
       libPath + 'papaparse/papaparse.js', // csv upload

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -51,8 +51,8 @@
       paths.src + 'vendor/ui-router-extras/release/ct-ui-router-extras.js',
       libPath + 'angular-ui-select2/src/select2.js',
       libPath + 'angular-i18n/angular-locale_en-gb.js',
-      paths.src + 'vendor/moment/moment.js',
-      paths.src + 'vendor/moment-timezone/builds/moment-timezone-with-data-2010-2020.js',
+      libPath + 'moment/moment.js', // required by moment-timezone
+      libPath + 'moment-timezone/builds/moment-timezone-with-data-2010-2020.js',
       libPath + 'angular-moment/angular-moment.js',
       libPath + 'angular-blocks/dist/angular-blocks.js',
       libPath + 'rome/dist/rome.standalone.js', // datepicker

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -67,7 +67,7 @@
       paths.src + 'vendor/angulartics-google-analytics/lib/angulartics-ga.js',
       paths.src + 'vendor/angular-hotkeys/build/hotkeys.js',
       paths.src + 'vendor/ng-text-truncate/ng-text-truncate.js',
-      paths.src + 'vendor/angular-local-storage/dist/angular-local-storage.js',
+      libPath + 'angular-local-storage/dist/angular-local-storage.js',
       paths.src + 'vendor/angularUtils/src/directives/pagination/dirPagination.js',
       paths.src + 'vendor/ng-idle/angular-idle.js',
       paths.src + 'javascripts/vendor/diff-match-patch/angular-diff-match-patch.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -64,7 +64,7 @@
       paths.src + 'vendor/socket.io-client/dist/socket.io.js',
       libPath + 'angular-socket-io/socket.js',
       paths.src + 'vendor/angulartics/src/angulartics.js',
-      paths.src + 'vendor/angulartics-google-analytics/lib/angulartics-ga.js',
+      libPath + 'angulartics-google-analytics/lib/angulartics-ga.js',
       paths.src + 'vendor/angular-hotkeys/build/hotkeys.js',
       paths.src + 'vendor/ng-text-truncate/ng-text-truncate.js',
       libPath + 'angular-local-storage/dist/angular-local-storage.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -47,7 +47,7 @@
       libPath + 'angular-animate/angular-animate.js',
       paths.src + 'vendor/angular-sticky/dist/angular-sticky.js',
       libPath + 'angular-resource/angular-resource.js',
-      paths.src + 'vendor/angular-ui-router/release/angular-ui-router.js',
+      libPath + 'angular-ui-router/release/angular-ui-router.js',
       paths.src + 'vendor/ui-router-extras/release/ct-ui-router-extras.js',
       paths.src + 'vendor/angular-ui-select2/src/select2.js',
       libPath + 'angular-i18n/angular-locale_en-gb.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -39,7 +39,7 @@
     vendor: [
       libPath + 'lodash/dist/lodash.js',
       libPath + 'jquery/dist/jquery.js',
-      paths.src + 'vendor/select2/select2.js',
+      libPath + 'select2/select2.js',
       // angular specific
       libPath + 'angular/angular.js',
       libPath + 'angular-sanitize/angular-sanitize.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -72,7 +72,7 @@
       paths.src + 'vendor/ng-idle/angular-idle.js',
       paths.src + 'javascripts/vendor/diff-match-patch/angular-diff-match-patch.js',
       paths.src + 'javascripts/vendor/diff-match-patch/google-diff-match-patch.js',
-      paths.src + 'vendor/papaparse/papaparse.js', // csv upload
+      libPath + 'papaparse/papaparse.js', // csv upload
       paths.src + 'vendor/FileSaver/FileSaver.js' // csv upload
     ],
     app: [

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -61,7 +61,7 @@
       libPath + 'conduitjs/lib/conduit.js',
       libPath + 'postal/lib/postal.js',
       libPath + 'angular-loading-bar/build/loading-bar.js',
-      paths.src + 'vendor/socket.io-client/dist/socket.io.js',
+      libPath + 'socket.io-client/dist/socket.io.js',
       libPath + 'angular-socket-io/socket.js',
       libPath + 'angulartics/src/angulartics.js',
       libPath + 'angulartics-google-analytics/lib/angulartics-ga.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -29,7 +29,7 @@
   // vendor scripts
   paths.vendor_static.push(paths.src + 'javascripts/vendor/**/*');
   paths.vendor_static.push(libPath + 'fullcalendar/fullcalendar.min.js');
-  paths.vendor_static.push(paths.src + 'vendor/raven-js/dist/angular/raven.js');
+  paths.vendor_static.push(libPath + 'raven-js/dist/angular/raven.js');
   // ignore certain vendor scripts from the copy
   paths.vendor_static.push('!' + paths.src + 'javascripts/vendor/diff-match-patch/');
   paths.vendor_static.push('!' + paths.src + 'javascripts/vendor/diff-match-patch/**');

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -66,7 +66,7 @@
       libPath + 'angulartics/src/angulartics.js',
       libPath + 'angulartics-google-analytics/lib/angulartics-ga.js',
       libPath + 'angular-hotkeys/build/hotkeys.js',
-      paths.src + 'vendor/ng-text-truncate/ng-text-truncate.js',
+      libPath + 'ng-text-truncate/ng-text-truncate.js',
       libPath + 'angular-local-storage/dist/angular-local-storage.js',
       paths.src + 'vendor/angularUtils/src/directives/pagination/dirPagination.js',
       paths.src + 'vendor/ng-idle/angular-idle.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -46,7 +46,7 @@
       paths.src + 'vendor/angular-messages/angular-messages.js',
       libPath + 'angular-animate/angular-animate.js',
       paths.src + 'vendor/angular-sticky/dist/angular-sticky.js',
-      paths.src + 'vendor/angular-resource/angular-resource.js',
+      libPath + 'angular-resource/angular-resource.js',
       paths.src + 'vendor/angular-ui-router/release/angular-ui-router.js',
       paths.src + 'vendor/ui-router-extras/release/ct-ui-router-extras.js',
       paths.src + 'vendor/angular-ui-select2/src/select2.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -60,7 +60,7 @@
       paths.src + 'vendor/angular-xeditable/dist/js/xeditable.js',
       paths.src + 'vendor/conduitjs/lib/conduit.js',
       paths.src + 'vendor/postal.js/lib/postal.js',
-      paths.src + 'vendor/angular-loading-bar/build/loading-bar.js',
+      libPath + 'angular-loading-bar/build/loading-bar.js',
       paths.src + 'vendor/socket.io-client/dist/socket.io.js',
       paths.src + 'vendor/angular-socket-io/socket.js',
       paths.src + 'vendor/angulartics/src/angulartics.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -57,7 +57,7 @@
       libPath + 'angular-blocks/dist/angular-blocks.js',
       libPath + 'rome/dist/rome.standalone.js', // datepicker
       paths.src + 'javascripts/vendor/ui-bootstrap-custom-tpls-1.3.3.js',
-      paths.src + 'vendor/angular-xeditable/dist/js/xeditable.js',
+      libPath + 'angular-xeditable/dist/js/xeditable.js',
       libPath + 'conduitjs/lib/conduit.js',
       libPath + 'postal/lib/postal.js',
       libPath + 'angular-loading-bar/build/loading-bar.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -58,7 +58,7 @@
       paths.src + 'vendor/rome/dist/rome.standalone.js', // datepicker
       paths.src + 'javascripts/vendor/ui-bootstrap-custom-tpls-1.3.3.js',
       paths.src + 'vendor/angular-xeditable/dist/js/xeditable.js',
-      paths.src + 'vendor/conduitjs/lib/conduit.js',
+      libPath + 'conduitjs/lib/conduit.js',
       libPath + 'postal/lib/postal.js',
       libPath + 'angular-loading-bar/build/loading-bar.js',
       paths.src + 'vendor/socket.io-client/dist/socket.io.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -65,7 +65,7 @@
       libPath + 'angular-socket-io/socket.js',
       libPath + 'angulartics/src/angulartics.js',
       libPath + 'angulartics-google-analytics/lib/angulartics-ga.js',
-      paths.src + 'vendor/angular-hotkeys/build/hotkeys.js',
+      libPath + 'angular-hotkeys/build/hotkeys.js',
       paths.src + 'vendor/ng-text-truncate/ng-text-truncate.js',
       libPath + 'angular-local-storage/dist/angular-local-storage.js',
       paths.src + 'vendor/angularUtils/src/directives/pagination/dirPagination.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -28,7 +28,7 @@
   paths.ng_partials.push(paths.src + 'javascripts/app/partials/**/*.html');
   // vendor scripts
   paths.vendor_static.push(paths.src + 'javascripts/vendor/**/*');
-  paths.vendor_static.push(paths.src + 'vendor/fullcalendar/fullcalendar.min.js');
+  paths.vendor_static.push(libPath + 'fullcalendar/fullcalendar.min.js');
   paths.vendor_static.push(paths.src + 'vendor/raven-js/dist/angular/raven.js');
   // ignore certain vendor scripts from the copy
   paths.vendor_static.push('!' + paths.src + 'javascripts/vendor/diff-match-patch/');

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -45,7 +45,7 @@
       libPath + 'angular-sanitize/angular-sanitize.js',
       libPath + 'angular-messages/angular-messages.js',
       libPath + 'angular-animate/angular-animate.js',
-      paths.src + 'vendor/angular-sticky/dist/angular-sticky.js',
+      libPath + 'angular-sticky-plugin/dist/angular-sticky.js',
       libPath + 'angular-resource/angular-resource.js',
       libPath + '@uirouter/angularjs/release/angular-ui-router.js',
       paths.src + 'vendor/ui-router-extras/release/ct-ui-router-extras.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -42,7 +42,7 @@
       paths.src + 'vendor/select2/select2.js',
       // angular specific
       libPath + 'angular/angular.js',
-      paths.src + 'vendor/angular-sanitize/angular-sanitize.js',
+      libPath + 'angular-sanitize/angular-sanitize.js',
       paths.src + 'vendor/angular-messages/angular-messages.js',
       libPath + 'angular-animate/angular-animate.js',
       paths.src + 'vendor/angular-sticky/dist/angular-sticky.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -62,7 +62,7 @@
       paths.src + 'vendor/postal.js/lib/postal.js',
       libPath + 'angular-loading-bar/build/loading-bar.js',
       paths.src + 'vendor/socket.io-client/dist/socket.io.js',
-      paths.src + 'vendor/angular-socket-io/socket.js',
+      libPath + 'angular-socket-io/socket.js',
       paths.src + 'vendor/angulartics/src/angulartics.js',
       paths.src + 'vendor/angulartics-google-analytics/lib/angulartics-ga.js',
       paths.src + 'vendor/angular-hotkeys/build/hotkeys.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -1,6 +1,7 @@
 (function(){
   'use strict';
 
+  var libPath = 'node_modules/';
   var paths = {
     tmp: '.gulptmp/',
     dest: 'cla_frontend/assets/',
@@ -40,7 +41,7 @@
       paths.src + 'vendor/jquery/jquery.js',
       paths.src + 'vendor/select2/select2.js',
       // angular specific
-      paths.src + 'vendor/angular/angular.js',
+      libPath + 'angular/angular.js',
       paths.src + 'vendor/angular-sanitize/angular-sanitize.js',
       paths.src + 'vendor/angular-messages/angular-messages.js',
       paths.src + 'vendor/angular-animate/angular-animate.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -44,7 +44,7 @@
       libPath + 'angular/angular.js',
       paths.src + 'vendor/angular-sanitize/angular-sanitize.js',
       paths.src + 'vendor/angular-messages/angular-messages.js',
-      paths.src + 'vendor/angular-animate/angular-animate.js',
+      libPath + 'angular-animate/angular-animate.js',
       paths.src + 'vendor/angular-sticky/dist/angular-sticky.js',
       paths.src + 'vendor/angular-resource/angular-resource.js',
       paths.src + 'vendor/angular-ui-router/release/angular-ui-router.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -73,7 +73,7 @@
       paths.src + 'javascripts/vendor/diff-match-patch/angular-diff-match-patch.js',
       paths.src + 'javascripts/vendor/diff-match-patch/google-diff-match-patch.js',
       libPath + 'papaparse/papaparse.js', // csv upload
-      paths.src + 'vendor/FileSaver/FileSaver.js' // csv upload
+      libPath + 'file-saver/FileSaver.js' // csv upload
     ],
     app: [
       paths.src + 'javascripts/app/js/app.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -49,7 +49,7 @@
       libPath + 'angular-resource/angular-resource.js',
       libPath + '@uirouter/angularjs/release/angular-ui-router.js',
       paths.src + 'vendor/ui-router-extras/release/ct-ui-router-extras.js',
-      paths.src + 'vendor/angular-ui-select2/src/select2.js',
+      libPath + 'angular-ui-select2/src/select2.js',
       libPath + 'angular-i18n/angular-locale_en-gb.js',
       paths.src + 'vendor/moment/moment.js',
       paths.src + 'vendor/moment-timezone/builds/moment-timezone-with-data-2010-2020.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -37,7 +37,7 @@
   // scripts
   paths.scripts = {
     vendor: [
-      paths.src + 'vendor/lodash/dist/lodash.js',
+      libPath + 'lodash/dist/lodash.js',
       paths.src + 'vendor/jquery/jquery.js',
       paths.src + 'vendor/select2/select2.js',
       // angular specific

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -55,7 +55,7 @@
       paths.src + 'vendor/moment-timezone/builds/moment-timezone-with-data-2010-2020.js',
       libPath + 'angular-moment/angular-moment.js',
       libPath + 'angular-blocks/dist/angular-blocks.js',
-      paths.src + 'vendor/rome/dist/rome.standalone.js', // datepicker
+      libPath + 'rome/dist/rome.standalone.js', // datepicker
       paths.src + 'javascripts/vendor/ui-bootstrap-custom-tpls-1.3.3.js',
       paths.src + 'vendor/angular-xeditable/dist/js/xeditable.js',
       libPath + 'conduitjs/lib/conduit.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -38,7 +38,7 @@
   paths.scripts = {
     vendor: [
       libPath + 'lodash/dist/lodash.js',
-      paths.src + 'vendor/jquery/jquery.js',
+      libPath + 'jquery/dist/jquery.js',
       paths.src + 'vendor/select2/select2.js',
       // angular specific
       libPath + 'angular/angular.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -54,7 +54,7 @@
       paths.src + 'vendor/moment/moment.js',
       paths.src + 'vendor/moment-timezone/builds/moment-timezone-with-data-2010-2020.js',
       paths.src + 'vendor/angular-moment/angular-moment.js',
-      paths.src + 'vendor/angular-blocks/dist/angular-blocks.js',
+      libPath + 'angular-blocks/dist/angular-blocks.js',
       paths.src + 'vendor/rome/dist/rome.standalone.js', // datepicker
       paths.src + 'javascripts/vendor/ui-bootstrap-custom-tpls-1.3.3.js',
       paths.src + 'vendor/angular-xeditable/dist/js/xeditable.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -50,7 +50,7 @@
       paths.src + 'vendor/angular-ui-router/release/angular-ui-router.js',
       paths.src + 'vendor/ui-router-extras/release/ct-ui-router-extras.js',
       paths.src + 'vendor/angular-ui-select2/src/select2.js',
-      paths.src + 'vendor/angular-i18n/angular-locale_en-gb.js',
+      libPath + 'angular-i18n/angular-locale_en-gb.js',
       paths.src + 'vendor/moment/moment.js',
       paths.src + 'vendor/moment-timezone/builds/moment-timezone-with-data-2010-2020.js',
       paths.src + 'vendor/angular-moment/angular-moment.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -47,7 +47,7 @@
       libPath + 'angular-animate/angular-animate.js',
       paths.src + 'vendor/angular-sticky/dist/angular-sticky.js',
       libPath + 'angular-resource/angular-resource.js',
-      libPath + 'angular-ui-router/release/angular-ui-router.js',
+      libPath + '@uirouter/angularjs/release/angular-ui-router.js',
       paths.src + 'vendor/ui-router-extras/release/ct-ui-router-extras.js',
       paths.src + 'vendor/angular-ui-select2/src/select2.js',
       libPath + 'angular-i18n/angular-locale_en-gb.js',

--- a/tasks/gulp/_paths.js
+++ b/tasks/gulp/_paths.js
@@ -48,7 +48,6 @@
       libPath + 'angular-sticky-plugin/dist/angular-sticky.js',
       libPath + 'angular-resource/angular-resource.js',
       libPath + '@uirouter/angularjs/release/angular-ui-router.js',
-      paths.src + 'vendor/ui-router-extras/release/ct-ui-router-extras.js',
       libPath + 'angular-ui-select2/src/select2.js',
       libPath + 'angular-i18n/angular-locale_en-gb.js',
       libPath + 'moment/moment.js', // required by moment-timezone

--- a/template_deploy/Dockerfile
+++ b/template_deploy/Dockerfile
@@ -89,13 +89,10 @@ COPY requirements/ ./requirements
 COPY requirements.txt ./
 RUN pip install -r requirements/production.txt && find . -name '*.pyc' -delete
 
-# Install node dependencies
+# Install node and front-end dependencies
+# NPM has now replaced bower for installing front-end dependencies
 COPY package.json package-lock.json ./
 RUN npm install
-
-# Install front-end dependencies
-COPY .bowerrc bower.json ./
-RUN npm run bower
 
 # Build front-end assets
 COPY tasks/ ./tasks

--- a/tests/angular-js/karma.conf.js
+++ b/tests/angular-js/karma.conf.js
@@ -7,7 +7,7 @@
       basePath : '../../',
 
       files : [
-        'cla_frontend/assets-src/vendor/raven-js/dist/angular/raven.js',
+        'node_modules/raven-js/dist/angular/raven.js',
         'cla_frontend/assets/javascripts/lib.min.js',
         'cla_frontend/assets/javascripts/cla.main.min.js',
         'node_modules/angular-mocks/angular-mocks.js',

--- a/tests/angular-js/karma.conf.js
+++ b/tests/angular-js/karma.conf.js
@@ -10,7 +10,7 @@
         'cla_frontend/assets-src/vendor/raven-js/dist/angular/raven.js',
         'cla_frontend/assets/javascripts/lib.min.js',
         'cla_frontend/assets/javascripts/cla.main.min.js',
-        'cla_frontend/assets-src/vendor/angular-mocks/angular-mocks.js',
+        'node_modules/angular-mocks/angular-mocks.js',
         'tests/angular-js/unit/**/*.js'
       ],
 


### PR DESCRIPTION
## What does this pull request do?

- Move all packages from bower to npm
- Change references for bower packages to npm
- Remove bower from circleci pipeline job and DockerFiles
- Includes `package-lock.json` to keep track of installed package versions

## Any other changes that would benefit highlighting?

Realised some package versions exist as bower package, but not in npm. Will need to reconsider how to reconcile this ie. what version to now use in npm.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
