### PR TITLE
LGA-1894 - Add external DNS annotations to ingress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,8 @@ jobs:
       - deploy:
           name: Deploy to << parameters.namespace >>
           command: |
+            export INGRESS_CLUSTER_NAME=`kubectl get configmap ingress-cluster -o jsonpath='{.data.name}'`
+            export INGRESS_CLUSTER_WEIGHT=`kubectl get configmap ingress-cluster -o jsonpath='{.data.weight}'`
             source .circleci/define_build_environment_variables << parameters.namespace >> << parameters.dynamic_hostname >>
             pip3 install requests
             export PINGDOM_IPS=`python3 bin/pingdom_ips.py`

--- a/bin/production_deploy.sh
+++ b/bin/production_deploy.sh
@@ -9,6 +9,8 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_PRODUCTION_NAMESPACE} \
   --values ${HELM_DIR}/values-production.yaml \
   --set host=$RELEASE_HOST \
+  --set ingress.cluster.name=${INGRESS_CLUSTER_NAME} \
+  --set ingress.cluster.weight=${INGRESS_CLUSTER_WEIGHT} \
   --set image.repository=$ECR_URL_APP \
   --set image.tag=$IMAGE_TAG \
   --set socketServer.image.repository=$ECR_URL_SOCKET_SERVER \

--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -9,6 +9,8 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_STAGING_NAMESPACE} \
   --values ${HELM_DIR}/values-staging.yaml \
   --set host=$RELEASE_HOST \
+  --set ingress.cluster.name=${INGRESS_CLUSTER_NAME} \
+  --set ingress.cluster.weight=${INGRESS_CLUSTER_WEIGHT} \
   --set image.repository=$ECR_URL_APP \
   --set image.tag=$IMAGE_TAG \
   --set socketServer.image.repository=$ECR_URL_SOCKET_SERVER \

--- a/bin/training_deploy.sh
+++ b/bin/training_deploy.sh
@@ -9,6 +9,8 @@ helm upgrade $RELEASE_NAME \
   --namespace=${KUBE_ENV_TRAINING_NAMESPACE} \
   --values ${HELM_DIR}/values-training.yaml \
   --set host=$RELEASE_HOST \
+  --set ingress.cluster.name=${INGRESS_CLUSTER_NAME} \
+  --set ingress.cluster.weight=${INGRESS_CLUSTER_WEIGHT} \
   --set image.repository=$ECR_URL_APP \
   --set image.tag=$IMAGE_TAG \
   --set socketServer.image.repository=$ECR_URL_SOCKET_SERVER \

--- a/bin/uat_deploy.sh
+++ b/bin/uat_deploy.sh
@@ -12,6 +12,8 @@ helm upgrade $RELEASE_NAME \
   --set fullnameOverride=$RELEASE_NAME \
   --set environment=$RELEASE_NAME \
   --set host=$RELEASE_HOST \
+  --set ingress.cluster.name=${INGRESS_CLUSTER_NAME} \
+  --set ingress.cluster.weight=${INGRESS_CLUSTER_WEIGHT} \
   --set image.repository=$ECR_URL_APP \
   --set image.tag=$IMAGE_TAG \
   --set socketServer.image.repository=$ECR_URL_SOCKET_SERVER \

--- a/helm_deploy/cla-frontend/templates/ingress.yaml
+++ b/helm_deploy/cla-frontend/templates/ingress.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     {{- include "cla-frontend.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.ingress.cluster.name }}
+    external-dns.alpha.kubernetes.io/set-identifier: "{{ $fullName }}-{{ .Release.Namespace }}-{{- .Values.ingress.cluster.name -}}"
+    external-dns.alpha.kubernetes.io/aws-weight: "{{- .Values.ingress.cluster.weight -}}"
+    {{- end }}
     {{- if .Values.ingress.whitelist }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ include "cla-frontend.whitelist" . }}"
     {{- end }}

--- a/helm_deploy/cla-frontend/values.yaml
+++ b/helm_deploy/cla-frontend/values.yaml
@@ -32,6 +32,9 @@ secretName: tls-certificate
 ingress:
   enabled: true
   annotations: {}
+  cluster:
+    name: ~
+    weight: ~
   whitelist:
     # MoJ
     - 81.134.202.29/32


### PR DESCRIPTION
## What does this pull request do?

- Add variable placeholders for cluster `name` and `weight` in `values.yaml`
- Add annotations to `ingress.yml` referencing the variables above
- Add parameters to all deployment scripts for setting (overriding) the cluster `name` and `weight` in `values.yaml`
- Create a `ingress-cluster` configmap with following values
    - `name` The cluster name i.e `blue` or `green`
    - `weight` The weighting of traffic that cluster should receive
- Update the circle config to read contents of `ingress-cluster` configmap and pass it to the deploy scripts as environment variables.

## Any other changes that would benefit highlighting?

Similar to https://github.com/ministryofjustice/cla_backend/pull/736

Command used to create configmap: `kubectl create configmap ingress-cluster --from-literal=name=blue --from-literal=weight=100`

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
