### PR TITLE
LGA-1922 Create deploy steps for uat namespace in live cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,6 +328,17 @@ workflows:
             - laa-cla-frontend-live1-uat
             - laa-cla-frontend-app-ecr
 
+      - deploy:
+          name: static_uat_deploy_live
+          namespace: uat
+          dynamic_hostname: false
+          requires:
+            - static_uat_deploy_approval
+          context:
+            - laa-cla-frontend
+            - laa-cla-frontend-live-uat
+            - laa-cla-frontend-app-ecr
+
       - staging_deploy_approval:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,6 +299,18 @@ workflows:
             - laa-cla-frontend-live1-uat
             - laa-cla-frontend-app-ecr
 
+      - deploy:
+          name: uat_deploy_live
+          namespace: uat
+          dynamic_hostname: true
+          requires:
+            - build_app
+            - build_socket_server
+          context:
+            - laa-cla-frontend
+            - laa-cla-frontend-live-uat
+            - laa-cla-frontend-app-ecr
+
       - static_uat_deploy_approval:
           type: approval
           requires:


### PR DESCRIPTION
## What does this pull request do?

- Create deploy steps for uat namespace in live cluster

## Any other changes that would benefit highlighting?

Have moved over secrets and configmap variables manually and created env vars in circleci context as `laa-cla-frontend-live-uat`

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
