### PR TITLE
LGA-1937 - Create reusable script to authenticate with cluster

### DIFF
--- a/.circleci/authenticate_with_kubernetes_cluster
+++ b/.circleci/authenticate_with_kubernetes_cluster
@@ -1,0 +1,8 @@
+#!/bin/sh -eu
+
+echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
+kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=${K8S_SERVER_ADDRESS}
+kubectl config set-credentials circleci --token=${K8S_TOKEN}
+kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
+kubectl config use-context ${K8S_CLUSTER_NAME}
+kubectl --namespace=${K8S_NAMESPACE} get pods

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,12 +210,7 @@ jobs:
       - run:
           name: Authenticate with cluster
           command: |
-            echo -n ${K8S_CLUSTER_CERT} | base64 -d > ./ca.crt
-            kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=./ca.crt --server=${K8S_SERVER_ADDRESS}
-            kubectl config set-credentials circleci --token=${K8S_TOKEN}
-            kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=circleci --namespace=${K8S_NAMESPACE}
-            kubectl config use-context ${K8S_CLUSTER_NAME}
-            kubectl --namespace=${K8S_NAMESPACE} get pods
+            .circleci/authenticate_with_kubernetes_cluster
       - deploy:
           name: Deploy to << parameters.namespace >>
           command: |
@@ -243,10 +238,9 @@ jobs:
             tar -zxvf helm-v3.1.2-linux-amd64.tar.gz
             mv linux-amd64/helm /usr/local/bin/helm
       - run:
-          name: Initialise Kubernetes uat context
+          name: Authenticate with cluster
           command: |
-            setup-kube-auth
-            kubectl config use-context uat
+            .circleci/authenticate_with_kubernetes_cluster
       - run:
           name: Delete uat release
           command: |
@@ -260,7 +254,15 @@ workflows:
       - python_unit_test
       - javascript_unit_test
       - cleanup_merged:
-          context: laa-cla-frontend
+          name: cleanup_merged_live1
+          context:
+            - laa-cla-frontend
+            - laa-cla-frontend-live1-uat
+      - cleanup_merged:
+          name: cleanup_merged_live
+          context:
+            - laa-cla-frontend
+            - laa-cla-frontend-live-uat
       - build_for_template_deploy:
           requires:
             - python_lint


### PR DESCRIPTION
## What does this pull request do?

Create reusable script to authenticate with cluster.
Remove missed setup-kube-auth in cleanup_merged job
Add `cleanup_merged` for each cluster

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
