### PR TITLE
LGA-1964 - Add angular service to detect enabled feature flags

### DIFF
--- a/cla_frontend/apps/call_centre/views.py
+++ b/cla_frontend/apps/call_centre/views.py
@@ -6,11 +6,17 @@ from cla_auth.utils import call_centre_zone_required
 
 @call_centre_zone_required
 def dashboard(request):
-    return render(
-        request,
-        "call_centre/angular_app.html",
-        {
-            "family_issue_flag": settings.FAMILY_ISSUE_FEATURE_FLAG,
-            "show_disregards_feature_flag": settings.SHOW_DISREGARDS_FEATURE_FLAG,
-        },
-    )
+    return render(request, "call_centre/angular_app.html", {"cla_features": get_enabled_feature_flags()})
+
+
+def get_enabled_feature_flags():
+    flags = {
+        "family_issue_flag": settings.FAMILY_ISSUE_FEATURE_FLAG,
+        "show_disregards_feature_flag": settings.SHOW_DISREGARDS_FEATURE_FLAG,
+    }
+    enabled = []
+    for name, value in flags.items():
+        if value:
+            enabled.append(name)
+
+    return enabled

--- a/cla_frontend/assets-src/javascripts/app/js/app.js
+++ b/cla_frontend/assets-src/javascripts/app/js/app.js
@@ -14,8 +14,8 @@
   var common_run;
   var common_config;
 
-  common_run = ['$rootScope', '$state', '$stateParams', 'Timer', 'flash', 'cla.bus', 'History', '$uibModal', 'AssignProviderValidation', 'postal',
-    function ($rootScope, $state, $stateParams, Timer, flash, bus, History, $uibModal, AssignProviderValidation, postal) {
+  common_run = ['$rootScope', '$state', '$stateParams', 'Timer', 'flash', 'cla.bus', 'History', '$uibModal', 'AssignProviderValidation', 'postal', 'ClaFeatures',
+    function ($rootScope, $state, $stateParams, Timer, flash, bus, History, $uibModal, AssignProviderValidation, postal, ClaFeatures) {
       $rootScope.$state = $state;
       $rootScope.$stateParams = $stateParams;
 
@@ -86,6 +86,10 @@
           }
         }
       });
+
+      $rootScope.is_cla_feature_enabled = function(name) {
+        return ClaFeatures.is_feature_enabled(name);
+      }
     }];
 
   common_config = ['$resourceProvider', 'cfpLoadingBarProvider', '$analyticsProvider',

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/eligibility_check.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/eligibility_check.js
@@ -18,10 +18,6 @@
               $scope.incomeWarnings = data.warnings;
             }
           });
-
-          $scope.family_issue_flag = window.family_issue_flag;
-          $scope.show_disregards_feature_flag = window.show_disregards_feature_flag;
-
           $scope.getCategoryForScriptNotes = function() {
             if($scope.inJudicialReview()) {
               return 'Judicial review';

--- a/cla_frontend/assets-src/javascripts/app/js/services/cla_features.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/cla_features.js
@@ -1,0 +1,16 @@
+(function () {
+  'use strict';
+
+  angular.module('cla.services')
+    .service('ClaFeatures', [function() {
+      try{
+        this.features = document.documentElement.getAttribute("cla-features").split(" ");
+      }
+      catch(error) {
+        this.features = [];
+      }
+      this.is_feature_enabled = function(name) {
+          return this.features.includes(name)
+      };
+    }]);
+})();

--- a/cla_frontend/assets-src/javascripts/app/js/services/cla_features.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/cla_features.js
@@ -4,7 +4,7 @@
   angular.module('cla.services')
     .service('ClaFeatures', [function() {
       try{
-        this.features = document.documentElement.getAttribute("cla-features").split(" ");
+        this.features = document.documentElement.getAttribute("data-cla-features").split(" ");
       }
       catch(error) {
         this.features = [];

--- a/cla_frontend/assets-src/javascripts/app/js/services/models.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/models.js
@@ -284,7 +284,7 @@
     }]);
 
   angular.module('cla.services')
-    .factory('Diagnosis', ['$http', '$claResource', 'DIAGNOSIS_SCOPE', 'url_utils', function($http, $claResource, DIAGNOSIS_SCOPE, url_utils) {
+    .factory('Diagnosis', ['$http', '$claResource', 'DIAGNOSIS_SCOPE', 'url_utils', 'ClaFeatures', function($http, $claResource, DIAGNOSIS_SCOPE, url_utils, ClaFeatures) {
       var resource;
 
       this.BASE_URL = url_utils.proxy('case/:case_reference/diagnosis/');
@@ -317,7 +317,7 @@
         return (this.state === undefined || this.state === DIAGNOSIS_SCOPE.UNKNOWN);
       };
       resource.prototype.isNonCLACategory = function(){
-        return this.category === 'family' && window.family_issue_flag;
+        return this.category === 'family' && ClaFeatures.is_feature_enabled("family_issue_flag");
       };
       resource.prototype.hasLetterOfProceedings = function() {
         if (this.nodes && this.nodes.length > 1) {

--- a/cla_frontend/assets-src/javascripts/app/partials/includes/eligibility.details.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/includes/eligibility.details.html
@@ -30,11 +30,11 @@
   </div>
 
   <div ng-switch-when="family">
-    <div ng-if="family_issue_flag">
+    <div ng-if="is_cla_feature_enabled('family_issue_flag')">
       <p>From the information you have given me today, you may be able to get free advice from a legal adviser in your area. Please enquire with the provider as there may be a charge for this service.</p>
       <p>Before I can provide you with the contact details for providers that are local to you, we need to complete a short financial assessment to see if you can get Legal Aid.</p>
     </div>
-    <div ng-if="!family_issue_flag">
+    <div ng-if="!is_cla_feature_enabled('family_issue_flag')">
       <p>From the information you have given today we may be able to put you through to a specialist provider who could help you with this area of law.</p>
       <p>Before I can transfer you we need to complete a short financial assessment to see if you can get Legal Aid. Do you have financial information to hand?</p>
       <p>You may need details of:</p>
@@ -129,7 +129,7 @@
   </div>
 </section>
 
-<div ng-if="show_disregards_feature_flag">
+<div ng-if="is_cla_feature_enabled('show_disregards_feature_flag')">
   <h2 class="FormBlock-label">Disregards <guidance-link doc="disregards"></guidance-link></h2>
   <call-script>
     <p>I am now going to read through a list of support schemes. Could you please tell me if you<span ng-show="hasPartner()"> or your partner</span> received any of these.</p>

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -146,7 +146,6 @@ CSP_DEFAULT_SRC = [
     "wss:",
     "www.google-analytics.com",
     "stats.g.doubleclick.net",
-    "'sha256-I2LOM6esOcAN2kEMLd3BbCCa/vshtQ3D4lkR5YJYKss='",
 ]
 if "localhost" in ALLOWED_HOSTS:
     CSP_DEFAULT_SRC += "localhost:*"
@@ -177,7 +176,7 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 SHOW_DISREGARDS_FEATURE_FLAG = os.environ.get("SHOW_DISREGARDS_QUESTIONS", "False").lower() == "true"
 
 # Sets whether the updated family issue text displays on in scope family cases or not
-FAMILY_ISSUE_FEATURE_FLAG = os.environ.get("FAMILY_ISSUE_FEATURE_FLAG", "False")
+FAMILY_ISSUE_FEATURE_FLAG = os.environ.get("FAMILY_ISSUE_FEATURE_FLAG", "False").lower() == "true"
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (

--- a/cla_frontend/templates/base.html
+++ b/cla_frontend/templates/base.html
@@ -3,7 +3,7 @@
 <html lang="en" {% block html_attrs %}ng-csp{% endblock %}
   data-analytics-id="{{ analytics_id }}"
   data-analytics-domain="{{ analytics_domain }}"
-  cla-features="{{ cla_features|join:' ' }}">
+  data-cla-features="{{ cla_features|join:' ' }}">
 
   <head data-sentry-dsn="{{ sentry_public_dsn }}" data-sentry-environment="{{ cla_environment }}"
         data-socketio-server="{{ socketio_server_url }}">

--- a/cla_frontend/templates/base.html
+++ b/cla_frontend/templates/base.html
@@ -2,7 +2,8 @@
 <!DOCTYPE html>
 <html lang="en" {% block html_attrs %}ng-csp{% endblock %}
   data-analytics-id="{{ analytics_id }}"
-  data-analytics-domain="{{ analytics_domain }}">
+  data-analytics-domain="{{ analytics_domain }}"
+  cla-features="{{ cla_features|join:' ' }}">
 
   <head data-sentry-dsn="{{ sentry_public_dsn }}" data-sentry-environment="{{ cla_environment }}"
         data-socketio-server="{{ socketio_server_url }}">
@@ -129,10 +130,6 @@
     </main>
 
     {% block base_javascript %}
-    <script type="text/javascript">
-      window.family_issue_flag = "{{ family_issue_flag }}" === "True";
-      window.show_disregards_feature_flag = "{{ show_disregards_feature_flag }}" === "True";
-    </script>
     <script src="{% static 'javascripts/lib.min.js' %}"></script>
     <script src="{% static 'javascripts/vendor/vanilla-js.js' %}"></script>
     <script src="{% staticmin 'javascripts/cla.main.js' %}"></script>


### PR DESCRIPTION
## What does this pull request do?

Add angular service to detect enabled feature flags

## Any other changes that would benefit highlighting?

Also switched from using an inline script with global variables to using html attribute for enabled feature names
The issue with using the inline script was that the hash had to be regenerated whenever there was a change to
the feature flag state and would have resulted to having hashes of multiple feature flag states

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
