### PR TITLE
Fix mismatching inline-script hash on production

### DIFF
--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -146,7 +146,7 @@ CSP_DEFAULT_SRC = [
     "wss:",
     "www.google-analytics.com",
     "stats.g.doubleclick.net",
-    "'sha256-sojeUjZY9Zvp3g0fCy0CKt8CUYK3HeSxnRtvOrLn1Nw='",
+    "'sha256-I2LOM6esOcAN2kEMLd3BbCCa/vshtQ3D4lkR5YJYKss='",
 ]
 if "localhost" in ALLOWED_HOSTS:
     CSP_DEFAULT_SRC += "localhost:*"


### PR DESCRIPTION
## What does this pull request do?

Fix mismatching inline-script hash on production

## Any other changes that would benefit highlighting?
We do not allow arbitrary inline-scripts to execute. Instead we take a hash of the inline script and only allow scripts matching that hash to execute.

Production is raising the following error in the console:
```
Either the 'unsafe-inline' keyword, a hash ('sha256-I2LOM6esOcAN2kEMLd3BbCCa/vshtQ3D4lkR5YJYKss='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'script-src' was not explicitly set, so 'default-src' is used as a fallback.
```
See https://github.com/ministryofjustice/cla_frontend/pull/778 for a long term fix

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
