### PR TITLE
LGA -1973 move disregards

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/partials/includes/eligibility.details.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/includes/eligibility.details.html
@@ -129,23 +129,3 @@
   </div>
 </section>
 
-<div ng-if="is_cla_feature_enabled('show_disregards_feature_flag')">
-  <h2 class="FormBlock-label">Disregards <guidance-link doc="disregards"></guidance-link></h2>
-  <call-script>
-    <p>I am now going to read through a list of support schemes. Could you please tell me if you<span ng-show="hasPartner()"> or your partner</span> received any of these.</p>
-  </call-script>
-  <section class="FormBlock FormBlock--grey">
-    <div class="FormRow cf" ng-repeat="opt in ::disregardOptions">
-      <p class="FormRow-label">{{ ::opt.text }}</p>
-
-      <label class="FormRow-option FormRow-option--inline">
-        <input type="radio" name="your_details-disregards-{{::opt.value}}" ng-value="true" ng-model="::eligibility_check.disregards[opt.value]" ng-change="benefitChange()">Yes
-      </label>
-
-      <label class="FormRow-option FormRow-option--inline">
-        <input type="radio" name="your_details-disregards-{{::opt.value}}" ng-value="false" ng-model="::eligibility_check.disregards[opt.value]" ng-change="benefitChange()">No
-      </label>
-    </div>
-  </section>
-</div>
-

--- a/cla_frontend/assets-src/javascripts/app/partials/includes/eligibility.finances.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/includes/eligibility.finances.html
@@ -185,3 +185,23 @@
     </div>
   </div>
 </section>
+
+<div ng-if="is_cla_feature_enabled('show_disregards_feature_flag')">
+  <h2 class="FormBlock-label">Disregards <guidance-link doc="disregards"></guidance-link></h2>
+  <call-script>
+    <p>I am now going to read through a list of support schemes. Could you please tell me if you<span ng-show="hasPartner()"> or your partner</span> received any of these.</p>
+  </call-script>
+  <section class="FormBlock FormBlock--grey">
+    <div class="FormRow cf" ng-repeat="opt in ::disregardOptions">
+      <p class="FormRow-label">{{ ::opt.text }}</p>
+
+      <label class="FormRow-option FormRow-option--inline">
+        <input type="radio" name="your_details-disregards-{{::opt.value}}" ng-value="true" ng-model="::eligibility_check.disregards[opt.value]" ng-change="benefitChange()">Yes
+      </label>
+
+      <label class="FormRow-option FormRow-option--inline">
+        <input type="radio" name="your_details-disregards-{{::opt.value}}" ng-value="false" ng-model="::eligibility_check.disregards[opt.value]" ng-change="benefitChange()">No
+      </label>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
## What does this pull request do?
Moves disregards questions from the Detail's sub-tab to the Finances sub-tab in CHS.

Ticket  LGA-1752 was created to add the disregards questions on the CHS. This work was completed and demoed to HGS. They pointed out that having it positioned in ‘Details’ sub-tab in the finances section could be confusing for operators as they may not need to ask the questions at the point which could lead to increased call times. It was determined that it would be better if the questions appeared under the ‘Finances’ sub-tab of the Finances tab


## Any other changes that would benefit highlighting?

For this change to be visible the environment variable SHOW_DISREGARDS_FEATURE_FLAG needs to be set to TRUE

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
