### PR TITLE
Remove readiness and liveness probes until bug with them failing is fixed

### DIFF
--- a/helm_deploy/cla-frontend/templates/deployment.yaml
+++ b/helm_deploy/cla-frontend/templates/deployment.yaml
@@ -22,20 +22,20 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /status/live/
-              port: http
-              httpHeaders:
-                - name: Host
-                  value: "{{ .Values.host }}"
-          readinessProbe:
-            httpGet:
-              path: /status/ready/
-              port: http
-              httpHeaders:
-                - name: Host
-                  value: "{{ .Values.host }}"
+#          livenessProbe:
+#            httpGet:
+#              path: /status/live/
+#              port: http
+#              httpHeaders:
+#                - name: Host
+#                  value: "{{ .Values.host }}"
+#          readinessProbe:
+#            httpGet:
+#              path: /status/ready/
+#              port: http
+#              httpHeaders:
+#                - name: Host
+#                  value: "{{ .Values.host }}"
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
## What does this pull request do?

Remove readiness and liveness probes until bug with them failing is fixed

## Any other changes that would benefit highlighting?
The probes have started intermittently failing as of today and causing the kubernetes pods to restart and crash causing the entire CHS website to be offline.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
