### PR TITLE
LGA-2070 - Restore pod probes

### DIFF
--- a/cla_frontend/apps/status/smoketests/__init__.py
+++ b/cla_frontend/apps/status/smoketests/__init__.py
@@ -1,3 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 class SmokeTestFail(Exception):
     pass
 
@@ -29,6 +34,7 @@ class SmokeTestRegistry(object):
             except SmokeTestFail as fail:
                 status = False
                 message = str(fail)
+                logger.info("SMOKETEST FAILURE - {}: {}".format(name, message))
             yield {"name": name, "status": status, "message": message}
 
 

--- a/cla_frontend/apps/status/smoketests/basic.py
+++ b/cla_frontend/apps/status/smoketests/basic.py
@@ -12,14 +12,12 @@ from status.smoketests import SmokeTestFail, ready_smoketests, live_smoketests
 
 
 @live_smoketests.register(1, "Public site is up")
-@ready_smoketests.register(1, "Public site is up")
 def things_exist():
     response = get_fe("/auth/login/")
     assert_status(response, 200)
 
 
 @live_smoketests.register(2, "Angular is loaded")
-@ready_smoketests.register(2, "Angular is loaded")
 def angular_loaded():
     url = static("javascripts/cla.main.js")
     if "://" in url:

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -257,7 +257,7 @@ LOGGING = {
         "console": {"level": "INFO", "class": "logging.StreamHandler", "formatter": "simple", "stream": sys.stdout}
     },
     "loggers": {
-        "": {"handlers": ["console"], "level": "ERROR", "propagate": False},
+        "": {"handlers": ["console"], "level": "INFO", "propagate": True},
         "django.request": {"handlers": ["console"], "level": "ERROR", "propagate": False},
     },
 }

--- a/helm_deploy/cla-frontend/templates/deployment.yaml
+++ b/helm_deploy/cla-frontend/templates/deployment.yaml
@@ -22,20 +22,20 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
-#          livenessProbe:
-#            httpGet:
-#              path: /status/live/
-#              port: http
-#              httpHeaders:
-#                - name: Host
-#                  value: "{{ .Values.host }}"
-#          readinessProbe:
-#            httpGet:
-#              path: /status/ready/
-#              port: http
-#              httpHeaders:
-#                - name: Host
-#                  value: "{{ .Values.host }}"
+          livenessProbe:
+            httpGet:
+              path: /status/live/
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.host }}"
+          readinessProbe:
+            httpGet:
+              path: /status/ready/
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: "{{ .Values.host }}"
           lifecycle:
             preStop:
               exec:

--- a/helm_deploy/cla-frontend/templates/deployment.yaml
+++ b/helm_deploy/cla-frontend/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
               containerPort: 8000
               protocol: TCP
           livenessProbe:
+            timeoutSeconds: 5
             httpGet:
               path: /status/live/
               port: http
@@ -30,6 +31,8 @@ spec:
                 - name: Host
                   value: "{{ .Values.host }}"
           readinessProbe:
+            timeoutSeconds: 5
+            initialDelaySeconds: 20
             httpGet:
               path: /status/ready/
               port: http

--- a/helm_deploy/cla-frontend/templates/socket-server-deployment.yaml
+++ b/helm_deploy/cla-frontend/templates/socket-server-deployment.yaml
@@ -30,6 +30,8 @@ spec:
                 - name: Origin
                   value: "localhost:"
           readinessProbe:
+            timeoutSeconds: 5
+            initialDelaySeconds: 10
             httpGet:
               path: /socket.io/?eio=3&transport=polling
               port: http


### PR DESCRIPTION
## What does this pull request do?

Restore pod probes
Remove smoke tests that contain request to the current app from the ready tests. 
Send INFO level logs to the console so that send info level logs to our logging system

## Any other changes that would benefit highlighting?
Remove smoke tests that contain request to the current app from the ready tests as the app might not be ready to deal with these requests yet. In theory this shouldn't be an issue because `initialDelaySeconds` is set. However the ready probes fail when these smoke tests are executed as part of the ready probes.

## Checklist
https://dsdmoj.atlassian.net/browse/LGA-2070
- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
