### PR TITLE
Amend UWSGI set up and Add Liveness Probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN chown -R app:app /home/app && \
 
 # Add file for liveness probe
 RUN touch /tmp/listen_queue_healthy && \
-    chown www-data:www-data /tmp/listen_queue_healthy
+    chown app:app /tmp/listen_queue_healthy
 
 USER 1000
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ COPY . .
 RUN chown -R app:app /home/app && \
     mkdir -p cla_frontend/assets
 
+# Add file for liveness probe
+RUN touch /tmp/listen_queue_healthy && \
+    chown www-data:www-data /tmp/listen_queue_healthy
+
 USER 1000
 EXPOSE 8000
 

--- a/docker/cla_frontend.ini
+++ b/docker/cla_frontend.ini
@@ -10,3 +10,4 @@ logformat={"process_name": "uwsgi", "timestamp_msec": %(tmsecs), "method": "%(me
 post-buffering = 1
 buffer-size=32768
 post-buffering-bufsize=32768
+http-workers=5

--- a/docker/cla_frontend.ini
+++ b/docker/cla_frontend.ini
@@ -11,3 +11,4 @@ post-buffering = 1
 buffer-size=32768
 post-buffering-bufsize=32768
 http-workers=5
+alarm=removefile cmd:rm /tmp/listen_queue_healthy

--- a/helm_deploy/cla-frontend/templates/deployment.yaml
+++ b/helm_deploy/cla-frontend/templates/deployment.yaml
@@ -22,6 +22,12 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - test 
+                - -f 
+                - /tmp/listen_queue_healthy
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
## What does this pull request do?

Amended UWSGI setup to increase http-workers to 5.

Added settings in UWSGI and created a new liveness probe that checks if a file is there or not.
 - Docker creates the file
 - WSGI alarm setting removes the file when it triggers
 - Liveness probe checks for the file, pod gets reset when that file is not found.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
