### PR TITLE
Enable Vacuum setting for uwsgi

### DIFF
--- a/docker/cla_frontend.ini
+++ b/docker/cla_frontend.ini
@@ -2,7 +2,7 @@
 http=0.0.0.0:8000
 master = true
 enable-threads = true
-processes = 2
+processes = 4
 env = DJANGO_SETTINGS_MODULE=cla_frontend.settings
 module = cla_frontend.wsgi:application
 logger-req=stdio
@@ -10,7 +10,8 @@ logformat={"process_name": "uwsgi", "timestamp_msec": %(tmsecs), "method": "%(me
 post-buffering = 1
 buffer-size=32768
 post-buffering-bufsize=32768
-http-workers=5
+http-workers=2
 alarm=removefile cmd:rm /tmp/listen_queue_healthy
 alarm-backlog=removefile
-harakiri=20
+harakiri=30
+vacuum = true


### PR DESCRIPTION
## What does this pull request do?

Enable Vacuum setting for uwsgi
Increase number of workers to 4
Decrease number of http-workers to 2 - Still trying to figure the impact of this config setting
Increase harakiri to 30 seconds to stop legitimate requests being killed off early

## Any other changes that would benefit highlighting?

The vacuum option will instruct uWSGI to clean up any temporary files or UNIX sockets it created, such as HTTP sockets, pidfiles, or admin FIFOs


## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
