### PR TITLE
Disable modsecurity json parser

### DIFF
--- a/helm_deploy/cla-frontend/templates/ingress.yaml
+++ b/helm_deploy/cla-frontend/templates/ingress.yaml
@@ -24,6 +24,8 @@ metadata:
         proxy_set_header Host $host;
       }
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleRemoveById 200001
     # Add annotation to exclude 503 error pages from the list the cloud-platform error pages
     # and use our error pages for 503 errors
     nginx.ingress.kubernetes.io/custom-http-errors: "413,502,504"


### PR DESCRIPTION
## What does this pull request do?

Disable modsecurity json parser

## Any other changes that would benefit highlighting?

This slows down requests with large json bodies like /provider/csvupload/

List of mod-security conf rule ids can be found at https://github.com/SpiderLabs/ModSecurity/blob/v3/master/modsecurity.conf-recommended#L29-L30

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
