### PR TITLE
LGA 1880 upgrade circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-  node: circleci/node@8.9.3
+  node: circleci/node@5.0.2
 jobs:
   build:
     parameters:
@@ -128,7 +128,7 @@ jobs:
       - checkout
       - node/install:
           install-yarn: true
-          node-version: '16.13'
+          node-version: '8.9.3'
       - restore_cache:
           keys:
             - node-v1-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
             python manage.py test --verbosity=2
   javascript_unit_test:
     docker:
-      - image: cimg/node:8.9.3
+      - image: circleci/node:8.9.3
         environment:
           DJANGO_SETTINGS_MODULE: cla_frontend.settings.test
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
+  node: circleci/node@8.9.3
 jobs:
   build:
     parameters:
@@ -120,11 +121,14 @@ jobs:
             python manage.py test --verbosity=2
   javascript_unit_test:
     docker:
-      - image: circleci/node:8.9.3
+      - image: cimg/node:18.8.0
         environment:
           DJANGO_SETTINGS_MODULE: cla_frontend.settings.test
     steps:
       - checkout
+      - node/install:
+          install-yarn: true
+          node-version: '16.13'
       - restore_cache:
           keys:
             - node-v1-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
             .circleci/tag_and_push_docker_image << parameters.image >>:$CIRCLE_SHA1 << parameters.image >>
   python_lint:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - run:
@@ -88,7 +88,7 @@ jobs:
             black --check cla_frontend
   python_unit_test:
     docker:
-      - image: circleci/python:2.7
+      - image: cimg/python:2.7
         environment:
           DJANGO_SETTINGS_MODULE: cla_frontend.settings.testing
           SECRET_KEY: testing_key
@@ -120,7 +120,7 @@ jobs:
             python manage.py test --verbosity=2
   javascript_unit_test:
     docker:
-      - image: circleci/node:8.9.3
+      - image: cimg/node:8.9.3
         environment:
           DJANGO_SETTINGS_MODULE: cla_frontend.settings.test
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
       - run:
           name: Install Node JS dependencies
           command: |
+            sudo apt-get update && sudo apt-get install -y libfontconfig
             ./npm_git_wrapper.sh
       - save_cache:
           key: node-v1-{{ checksum "package-lock.json" }}


### PR DESCRIPTION
## What does this pull request do?

circleci image upgrade

note: now use an orb for install node version, and then just use the most recent node cimg.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
