### PR TITLE
LGA-2251 - Communicate with backend using a service name

### DIFF
--- a/helm_deploy/cla-frontend/values-production.yaml
+++ b/helm_deploy/cla-frontend/values-production.yaml
@@ -12,7 +12,8 @@ ingress:
 
 envVars:
   BACKEND_BASE_URI:
-    value: "https://fox.civillegaladvice.service.gov.uk"
+    # Using service name instead of external domain name
+    value: "http://cla-backend-app.laa-cla-backend-production.svc.cluster.local"
   GA_ID:
     value: UA-37377084-19
   GA_DOMAIN:

--- a/helm_deploy/cla-frontend/values-staging.yaml
+++ b/helm_deploy/cla-frontend/values-staging.yaml
@@ -5,7 +5,8 @@ environment: "staging"
 
 envVars:
   BACKEND_BASE_URI:
-    value: "https://staging.fox.civillegaladvice.service.gov.uk"
+    # Using service name instead of external domain name
+    value: "http://cla-backend-app.laa-cla-backend-staging.svc.cluster.local"
   GA_ID:
     value: UA-37377084-24
   GA_DOMAIN:

--- a/helm_deploy/cla-frontend/values-training.yaml
+++ b/helm_deploy/cla-frontend/values-training.yaml
@@ -8,7 +8,8 @@ ingress:
 
 envVars:
   BACKEND_BASE_URI:
-    value: "https://training.fox.civillegaladvice.service.gov.uk"
+    # Using service name instead of external domain name
+    value: "http://cla-backend-app.laa-cla-backend-training.svc.cluster.local"
   GA_ID:
     value: UA-37377084-20
   GA_DOMAIN:

--- a/helm_deploy/cla-frontend/values-uat.yaml
+++ b/helm_deploy/cla-frontend/values-uat.yaml
@@ -7,7 +7,8 @@ secretName: ~
 
 envVars:
   BACKEND_BASE_URI:
-    value: "https://laa-cla-backend-uat.apps.live-1.cloud-platform.service.justice.gov.uk"
+    # Using service name instead of external domain name
+    value: "http://cla-backend-app.laa-cla-backend-uat.svc.cluster.local"
   GA_ID:
     value: UA-37377084-24
   GA_DOMAIN:


### PR DESCRIPTION
## What does this pull request do?

Communicate with backend using a service name
**Requires** https://github.com/ministryofjustice/cla_backend/pull/851

## Any other changes that would benefit highlighting?
This an attempt to alleviate the issue of frontend sometimes timing out/reported sluggishness when trying to reach backend.

This fix will keep frontend to backend communication within the cluster instead request leaving the cluster and coming back again.

Requires the following PRs to allow namespaces to communicate with each other using a service name:
- production - https://github.com/ministryofjustice/cloud-platform-environments/pull/8704
- training - https://github.com/ministryofjustice/cloud-platform-environments/pull/8702
- staging - https://github.com/ministryofjustice/cloud-platform-environments/pull/8701

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
