### PR TITLE
LGA-1965 - Add end-2-end tests to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,8 @@ workflows:
             - laa-cla-frontend-socket-server-ecr
       - cla-end-to-end-tests/behave:
           requires:
-            - build
+            - build_socket_server
+            - build_app
           context: laa-cla-frontend
           pre-steps:
             - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   node: circleci/node@5.0.2
+  cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
 jobs:
   build:
     parameters:
@@ -249,6 +250,19 @@ workflows:
           context:
             - laa-cla-frontend
             - laa-cla-frontend-socket-server-ecr
+      - cla-end-to-end-tests/behave:
+          requires:
+            - build
+          context: laa-cla-frontend
+          pre-steps:
+            - checkout:
+                path: cla_frontend
+            - run:
+                command: |
+                  cd cla_frontend
+                  source .circleci/define_build_environment_variables testing
+                  echo "export CLA_FRONTEND_IMAGE=$ECR_DEPLOY_IMAGE" >> $BASH_ENV
+                  echo "Setting CLA Frontend image $ECR_DEPLOY_IMAGE"
 
       - deploy:
           name: uat_deploy_live

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,8 @@ django-proxy==1.0.2
 django-csp==2.0.3
 django-session-security==2.2.3
 django-statsd-mozilla==0.3.14
+# Pin statsd version to support Python 2.7
+statsd==3.3.0
 logstash-formatter==0.5.9
 django-ipware==0.1.0
 pyjade==3.0.0


### PR DESCRIPTION
## What does this pull request do?

- [x] Added the end-2-end tests into the CircleCI build and deploy pipeline.

## Any other changes that would benefit highlighting?

- [x] the version of `statsd` was pinned to 3.3.0 to ensure compatibility with python 2.7 as this was causing the pipeline to fail.

