### PR TITLE
LGA-2369 - Explicitly use laa-cla-frontend-app-ecr context when access to ecr is required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,7 @@ workflows:
           name: cleanup_merged_live
           context:
             - laa-cla-frontend
+            - laa-cla-frontend-app-ecr
             - laa-cla-frontend-live-uat
       - build:
           name: build_app
@@ -274,7 +275,9 @@ workflows:
           requires:
             - build_socket_server
             - build_app
-          context: laa-cla-frontend
+          context:
+            - laa-cla-frontend
+            - laa-cla-frontend-app-ecr
           pre-steps:
             - checkout:
                 path: cla_frontend


### PR DESCRIPTION
## What does this pull request do?

Explicitly use laa-cla-frontend-app-ecr context when access to ecr is required

## Any other changes that would benefit highlighting?

We had ECR credentials in both laa-cla-frontend and laa-cla-frontend-app-ecr contexts. I have removed it from the laa-cla-frontend context and made sure that the laa-cla-frontend-app-ecr context is used anywhere ECR access is required

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
