### PR TITLE
LGA-2392 - Do not submit the entire scope diagnosis form when creating a scope

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/partials/case_detail.edit.diagnosis.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/case_detail.edit.diagnosis.html
@@ -30,7 +30,7 @@
   </div>
 
   <div class="FormActions">
-    <button type="submit" name="diagnosis-new" class="Button" ng-click="createDiagnosis()" ng-if="!diagnosis.reference">Create scope diagnosis</button>
+    <button type="button" name="diagnosis-new" class="Button" ng-click="createDiagnosis()" ng-if="!diagnosis.reference">Create scope diagnosis</button>
 
     <button type="submit" name="diagnosis-next" class="Button" ng-if="!diagnosis.version_in_conflict && diagnosis.isInScopeUnknown() && diagnosis.reference">Next</button>
     <button type="button" name="diagnosis-back" class="Button Button--text" ng-if="!diagnosis.version_in_conflict && diagnosis.nodes && diagnosis.isInScopeUnknown()" ng-click="moveUp()">Back</button>


### PR DESCRIPTION
## What does this pull request do?

Do not submit the entire scope diagnosis form when creating a scope

## Any other changes that would benefit highlighting?

This was causing the form submission and the on-click handler for that button to be triggered simultaneously.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
