### PR TITLE
LGA-2617 Updated registry to herokuapp

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,5 +1,6 @@
 {
   "directory": "cla_frontend/assets-src/vendor",
   "interactive": false,
-  "allow_root": true
+  "allow_root": true,
+  "registry": "https://bower.herokuapp.com"
 }


### PR DESCRIPTION
## What does this pull request do?

Changes the bower registry in bowerrc to the herokuapp link.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
