### PR TITLE
Removed context for frontend app ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,6 @@ workflows:
           name: cleanup_merged_live
           context:
             - laa-cla-frontend
-            - laa-cla-frontend-app-ecr
             - laa-cla-frontend-live-uat
       - build:
           name: build_app
@@ -298,7 +297,6 @@ workflows:
             - javascript_unit_test
           context:
             - laa-cla-frontend
-            - laa-cla-frontend-app-ecr
       - build:
           name: build_socket_server
           image: socket-server
@@ -317,7 +315,6 @@ workflows:
             - build_app
           context:
             - laa-cla-frontend
-            - laa-cla-frontend-app-ecr
 
       - deploy:
           name: uat_deploy_live
@@ -329,7 +326,6 @@ workflows:
           context:
             - laa-cla-frontend
             - laa-cla-frontend-live-uat
-            - laa-cla-frontend-app-ecr
 
       - static_uat_deploy_approval:
           type: approval
@@ -346,7 +342,6 @@ workflows:
           context:
             - laa-cla-frontend
             - laa-cla-frontend-live-uat
-            - laa-cla-frontend-app-ecr
 
       - staging_deploy_approval:
           type: approval
@@ -367,7 +362,6 @@ workflows:
           context:
             - laa-cla-frontend
             - laa-cla-frontend-live-staging
-            - laa-cla-frontend-app-ecr
 
       - production_deploy_approval:
           requires:
@@ -387,7 +381,6 @@ workflows:
           context:
             - laa-cla-frontend
             - laa-cla-frontend-live-training
-            - laa-cla-frontend-app-ecr
 
       - deploy:
           name: production_deploy_live
@@ -398,4 +391,3 @@ workflows:
           context:
             - laa-cla-frontend
             - laa-cla-frontend-live-production
-            - laa-cla-frontend-app-ecr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,6 @@ workflows:
             - socket_server_tests
           context:
             - laa-cla-frontend
-            - laa-cla-frontend-socket-server-ecr
       - behave:
           requires:
             - build_socket_server


### PR DESCRIPTION
## What does this pull request do?

Removes the context laa-cla-frontend-app-ecr from the config circle ci file. This context is now no longer needed but is used in the current config build of cla_frontend. By removing it from the config file, we can delete the obsolete context from circle ci.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
