### PR TITLE
LGA-2677: Updated documentation regarding BACKEND_BASE_URI in .example.local.py

### DIFF
--- a/cla_frontend/settings/.example.local.py
+++ b/cla_frontend/settings/.example.local.py
@@ -1,6 +1,9 @@
 from .base import *
 
-# Overwriting BACKEND_BASE_URI will have no effect unless the ZONE_PROFILES dict is updated with the new value
+# If the backend ports need to be changed locally or in the Docker file, changing BACKEND_BASE_URI has no effect,
+# as the address is written to ZONE_PROFILES before being read from this file.
+# To point the backend to an address besides "127.0.0.1:8000" either alter your environment variables or overwrite
+# the ZONE_PROFILES dict with the new backend address by adding it to this file.
 
 DEBUG = True
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]

--- a/cla_frontend/settings/.example.local.py
+++ b/cla_frontend/settings/.example.local.py
@@ -1,5 +1,7 @@
 from .base import *
 
+# Overwriting BACKEND_BASE_URI will have no effect unless the ZONE_PROFILES dict is updated with the new value
+
 DEBUG = True
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 


### PR DESCRIPTION
## What does this pull request do?

Adds comments in the example.local.py file, documenting a unique interaction where changing an environment variable will not have the desired effect unless the Zone Profile dictionary is also updated.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
