### PR TITLE
LGA-2673  fix admin app socket namespace

### DIFF
--- a/cla_socketserver/app.js
+++ b/cla_socketserver/app.js
@@ -26,11 +26,12 @@ app.use(function(err, req, res, next){
   res.render('error', { error: err });
 });
 
-// ADMIN
-adminApp.install(app, socketServer);
 
 // SOCKETS
 const socketNamespace = socketServer.of('/socket.io');
+
+// ADMIN
+adminApp.install(app, socketNamespace);
 
 socketNamespace.on('connection', function (socket) {
   socket.on('identify', function(data) {


### PR DESCRIPTION
## What does this pull request do?

Fix adminApp.install to receive a SocketNamespace function which it is expecting to receive instead of the  SocketServer object which it is currently receiving

## Any other changes that would benefit highlighting?

This was causing the CHS not to receive notifications in realtime

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
