### PR TITLE
LGA-2534 Replacing incorrect email address with correct data protecti…

### DIFF
--- a/cla_frontend/templates/cla_provider/legal_help_form.jade
+++ b/cla_frontend/templates/cla_provider/legal_help_form.jade
@@ -450,20 +450,20 @@ html(lang='en')
       .page.box
         h2.section-heading Privacy notice
         p
-            strong Purpose 
+            strong Purpose
             br
         p This privacy notice sets out the standards that you can expect from the Legal Aid Agency when we request or hold personal information (‘personal data’) about you; how you can get access to a copy of your personal data; and what you can do if you think the standards are not being met.
         p The Legal Aid Agency is an Executive Agency of the Ministry of Justice (MoJ). The MoJ is the data controller for the personal information we hold. The Legal Aid Agency collects and processes personal data for the exercise of its own and associated public functions. Our public function is to provide legal aid.
         p
-            strong About personal information 
+            strong About personal information
             br
         p Personal data is information about you as an individual. It can be your name, address or telephone number. It can also include the information that you have provided in this form such as your financial circumstances and information relating to any current or previous legal proceedings concerning you.
         p We know how important it is to protect customers’ privacy and to comply with data protection laws. We will safeguard your personal data and will only disclose it where it is lawful to do so, or with your consent.
-        p 
+        p
             strong Types of personal data we process
             br
         p We only process personal data that is relevant for the services we are providing to you. The personal data which you have provided on this form will be used for the purposes set out below.
-        p 
+        p
             strong Purpose of processing and the lawful basis for the process
             br
         p The purpose of the Legal Aid Agency collecting and processing the personal data which you have provided on this form is for the purposes of providing legal aid. Specifically, we will use this personal data in the following ways:
@@ -475,33 +475,33 @@ html(lang='en')
         p Were the Legal Aid Agency unable to collect this personal information, we would not be able to conduct the activities above, which would prevent us from providing legal aid.
         p The lawful basis for the Legal Aid Agency collecting and processing your personal data is in the administration of justice and the result of the powers contained in Legal Aid, Sentencing and Punishment of Offenders Act 2012.
         p We also collect ‘special categories of personal data’ for the purposes of monitoring equality, this is a legal requirement for public authorities under the Equality Act 2010. Special categories of personal data obtained for equality monitoring will be treated with the strictest confidence and any information published will not identify you or anyone else associated with your legal aid application.
-        p 
-            strong Who the information may be shared with 
+        p
+            strong Who the information may be shared with
             br
-        p We sometimes need to share the personal information we process with other organisations. When this is necessary, we will comply with all aspects of the relevant data protection laws. The organisations we may share your personal information include: 
+        p We sometimes need to share the personal information we process with other organisations. When this is necessary, we will comply with all aspects of the relevant data protection laws. The organisations we may share your personal information include:
         ul
            li Public authorities such as: HM Courts and Tribunals Service (HMCTS), HM Revenue and Customs (HMRC), Department of Work and Pensions (DWP) and HM Land Registry;
-           li Non-public authorities such as: Credit reference agencies Equifax and TransUnion and our debt collection partners Marston Holdings; and 
+           li Non-public authorities such as: Credit reference agencies Equifax and TransUnion and our debt collection partners Marston Holdings; and
            li If false or inaccurate information is provided or fraud identified, the Legal Aid Agency can lawfully share your personal information with fraud prevention agencies to detect and to prevent fraud and money laundering.
-        p You can contact our Data Protection Officer for further information on the organisations we may share your personal information with. 
-        p 
+        p You can contact our Data Protection Officer for further information on the organisations we may share your personal information with.
+        p
             strong Data processors
             br
         p The LAA may contract with third party data processors to provide email, system administration, document management and IT storage services.
-        p Any personal data shared with a data processor for this purpose will be governed by model contract clauses under data protection law.  
-        p 
-            strong Details of transfers to third country and safeguards 
+        p Any personal data shared with a data processor for this purpose will be governed by model contract clauses under data protection law.
+        p
+            strong Details of transfers to third country and safeguards
             br
         p It may sometimes be necessary to transfer personal information overseas. When this is needed, information may be transferred to: the European Economic Area (EEA).
         p Any transfers made will be in full compliance with all aspects of the data protection law.
-        p 
-            strong Retention period for information collected 
-            br 
-        p Your personal information will not be retained for any longer than is necessary for the lawful purposes for which it has been collected and processed. This is to ensure that your personal information does not become inaccurate, out of date or irrelevant. The Legal Aid Agency have set retention periods for the personal information that we collect, this can be accessed via our website: 
+        p
+            strong Retention period for information collected
+            br
+        p Your personal information will not be retained for any longer than is necessary for the lawful purposes for which it has been collected and processed. This is to ensure that your personal information does not become inaccurate, out of date or irrelevant. The Legal Aid Agency have set retention periods for the personal information that we collect, this can be accessed via our website:
         a(target='_blank', href='https://www.gov.uk/government/publications/record-retention-and-disposition-schedules') https://www.gov.uk/government/publications/record-retention-and-disposition-schedules
         p You can also contact our Data Protection Officer for a copy of our retention policies.
         p While we retain your personal data, we will ensure that it is kept securely and protected from loss, misuse or unauthorised access and disclosure. Once the retention period has been reached, your personal data will be permanently and securely deleted and destroyed.
-        p 
+        p
             strong Access to personal information
             br
         p You can find out if we hold any personal data about you by making a ‘subject access request’. If you wish to make a subject access request please contact:
@@ -516,8 +516,8 @@ html(lang='en')
           br
           |  SW1H 9AJ
         p
-          a(target='_blank', href='mailto: data.access@justice.gov.uk') data.access@justice.gov.uk 
-        p 
+          a(target='_blank', href='mailto: data.access@justice.gov.uk') data.access@justice.gov.uk
+        p
             strong When we ask you for personal data
             br
         p We promise to inform you why we need your personal data and ask only for the personal data we need and not collect information that is irrelevant or excessive.
@@ -530,7 +530,7 @@ html(lang='en')
           li That we don’t keep it longer than is necessary;
           li That we will not make your personal data available for commercial use without your consent; and
           li That we will consider your request to correct, stop processing or erase your personal data.
-        p 
+        p
             strong You can get more details on:
             br
         ul
@@ -554,19 +554,19 @@ html(lang='en')
           |  London
           br
           |  SW1H 9AJ
-        p 
-          a(target='_blank', href='mailto: privacy@justice.gov.uk') privacy@justice.gov.uk 
+        p
+          a(target='_blank', href='mailto: DataProtection@justice.gov.uk') DataProtection@justice.gov.uk
         p For more information on how and why your information is processed, please see the information provided when you accessed our services or were contacted by us.
-        p 
+        p
             strong Complaints
             br
-        p When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at: 
+        p When we ask you for information, we will comply with the law. If you consider that your information has been handled incorrectly, you can contact the Information Commissioner for independent advice about data protection. You can contact the Information Commissioner at:
         p.postal-address
           | Information Commissioner's Office
           br
           |  Wycliffe House
           br
-          |  Water Lane 
+          |  Water Lane
           br
           |  Wilmslow
           br
@@ -574,10 +574,10 @@ html(lang='en')
           br
           |  SK9 5AF
           br
-          |  Tel: 0303 123 1113 
-        p 
+          |  Tel: 0303 123 1113
+        p
           a(target='_blank', href='www.ico.org.uk') www.ico.org.uk
-       
+
       // Notes
       .page.box.notes
         h2.section-heading Notes
@@ -629,9 +629,9 @@ html(lang='en')
         p
           strong Further Guidance
         p
-          | For a full guide to determining eligibility see the 
+          | For a full guide to determining eligibility see the
           a(target='_blank', href='https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/957563/Lord_Chancellor_s_guidance_on_determining_controlled_work__and_family_mediation.pdf') Guide to Determining Financial Eligibility for Controlled Work and Family Mediation April 2013 v1
-          
+
       // Advisor use, Time spent
       .page
         .box


### PR DESCRIPTION
## What does this pull request do?

The current template includes a privacy notice with an access to personal information section that is out of date. The email address referred to no longer works.

It sends people to [privacy@justice.gov.uk](mailto:privacy@justice.gov.uk)  when it should be [DataProtection@justice.gov.uk](mailto:DataProtection@justice.gov.uk)

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

[LGA-2534](https://dsdmoj.atlassian.net/browse/LGA-2534)


[LGA-2534]: https://dsdmoj.atlassian.net/browse/LGA-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ