### PR TITLE
LGA-2885 Allow access from Global Protect VPN

### DIFF
--- a/helm_deploy/cla-frontend/values.yaml
+++ b/helm_deploy/cla-frontend/values.yaml
@@ -43,7 +43,7 @@ ingress:
     name: ~
     weight: ~
   whitelist:
-    # MoJ
+    # MoJ Digital Wifi & Digital VPN
     - 81.134.202.29/32
     # MoJ/LAA
     - 52.17.239.55/32
@@ -78,6 +78,11 @@ ingress:
     - 185.91.131.4/32
     # CHS
     - 52.210.114.89/32
+    # GlobalProtect VPN (Digital Mac)
+    - 18.169.147.172/32
+    - 35.176.93.186/32
+    - 18.130.148.126/32
+    - 35.176.148.126/32
 
 envVars:
   STATIC_FILES_BACKEND:


### PR DESCRIPTION
## What does this pull request do?

This PR gives access via Global Protect VPN, since Digital VPN is disappearing. See more here: https://github.com/ministryofjustice/cla_backend/pull/1109

Tested successfully on the branch environment, with just GlobalProtect VPN enabled: https://allow-access-from-globalprot-laa-cla-frontend-uat.apps.live-1.cloud-platform.service.justice.gov.uk/auth/login/

This covers the "Global Protect users can access CLA Frontend" part of [LGA-2885](https://dsdmoj.atlassian.net/browse/LGA-2885).

This PR doesn't remove access from "MoJ Digital Wifi & Digital VPN". Rather than switch off access from that in this same deployment, I suggest we have a short period of overlap, where both VPNs can be used, to allow all devs to check the new arrangement works for everyone. So removing that IP from the list can be a follow up change.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"


[LGA-2885]: https://dsdmoj.atlassian.net/browse/LGA-2885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ