### PR TITLE
LGA-2994: Update CircleCI Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ orbs:
   slack: circleci/slack@3.4.2
   node: circleci/node@5.0.2
   cla-end-to-end-tests: ministryofjustice/cla-end-to-end-tests@volatile
-  aws-cli: circleci/aws-cli@4.0.0 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-cli: circleci/aws-cli@4.1 # use v4 of this orb
+  aws-ecr: circleci/aws-ecr@9.0 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 # ------------------
 # EXECUTORS
@@ -72,8 +72,9 @@ jobs:
           condition:
             equal: ["app", << parameters.image >>]
           steps:
-            - aws-ecr/build-image:
-                push-image: true
+            - aws-ecr/build_image:
+                push_image: true
+                account_id: $AWS_ECR_REGISTRY_ID
                 tag: $BUILD_TAGS
                 region: $ECR_REGION # this will use the env var
                 repo: $ECR_APP_REPOSITORY # this will use the env var
@@ -86,10 +87,11 @@ jobs:
           condition:
             equal: ["socket-server", << parameters.image >>]
           steps:
-            - aws-ecr/build-image:
-                push-image: true
+            - aws-ecr/build_image:
+                push_image: true
+                account_id: $AWS_ECR_REGISTRY_ID
                 path: cla_socketserver
-                build-path: cla_socketserver
+                build_path: cla_socketserver
                 tag: $BUILD_TAGS
                 region: $ECR_REGION # this will use the env var
                 repo: $ECR_SOCKET_SERVER_REPOSITORY


### PR DESCRIPTION
## What does this pull request do?

- Updates the AWS ECR Orb to the latest version: [v9.0.2](https://github.com/CircleCI-Public/aws-ecr-orb/releases/tag/v9.0.2)
- Updates the AWS CLI Orb to the latest version: [v4.1.3](https://github.com/CircleCI-Public/aws-cli-orb/releases/tag/v4.1.3)
- Adds `account_id` to `build_image`

### Why are we doing this?
The previous versions of the AWS Orbs were reliant on a version of ubuntu which is being depreciated by CircleCI. 
These orbs need to be updated so we can continue to deploy with our CircleCI pipeline.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"