### PR TITLE
LGA-2989 - Hide All environments from search engines

### DIFF
--- a/helm_deploy/cla-frontend/templates/ingress.yaml
+++ b/helm_deploy/cla-frontend/templates/ingress.yaml
@@ -16,7 +16,8 @@ metadata:
     {{- if .Values.ingress.whitelist }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ include "cla-frontend.whitelist" . }}"
     {{- end }}
-    nginx.ingress.kubernetes.io/server-snippets: |
+    nginx.ingress.kubernetes.io/server-snippet: |
+      add_header X-Robots-Tag "noindex, nofollow";
       location /socket.io {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
## What does this pull request do?

Hide All environments from search engines.

## Any other changes that would benefit highlighting?

Previously the annotation `nginx.ingress.kubernetes.io/server-snippets` was used on the ingress, however there is no such annotation, the correct annotation is `nginx.ingress.kubernetes.io/server-snippet`

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
