### PR TITLE
LGA-3156 reset skipped value for each means test in CHS

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/controllers/eligibility_check.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/eligibility_check.js
@@ -10,6 +10,9 @@
           // set nass benefits to FALSE by default
           $scope.eligibility_check.on_nass_benefits = $scope.eligibility_check.on_nass_benefits || false;
 
+          // Variable to track skipping eligibility in GA4
+          $scope.skipped_eligibility = false;
+
           // income warnings
           postal.subscribe({
             channel: 'IncomeWarnings',
@@ -309,6 +312,7 @@
               // updates the state of case.eligibility_state after each save
               $scope.case.state = data.state;
               $window.dataLayer.push({ 'event': 'MeansEligibilityChecked', 'MeansEligibilitySkipped': $scope.skipped_eligibility, 'MeansEligibilityResult': data.state });
+              $scope.skipped_eligibility = false;
 
               // publish eligibility save
               postal.publish({


### PR DESCRIPTION
## What does this pull request do?

Default skipped means eligibility to false and reset to false after each time it's tracked.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
