### PR TITLE
LGA-3272: Adds the Shared LAA IP Ranges to the staging environment

### DIFF
--- a/bin/staging_deploy.sh
+++ b/bin/staging_deploy.sh
@@ -20,4 +20,5 @@ helm upgrade $RELEASE_NAME \
   --set socketServer.image.repository=$ECR_URL_SOCKET_SERVER \
   --set socketServer.image.tag=$IMAGE_TAG \
   --set-string pingdomIPs=$PINGDOM_IPS \
+  --set-string sharedIPRangesLAA=$SHARED_IP_RANGES_LAA \
   --install


### PR DESCRIPTION
## What does this pull request do?

- Adds the Shared LAA IP Ranges to the staging_deploy.sh, this was erroneously missed in this Pull Request:
#975 

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
