### PR TITLE
Update operator manager to match that of whats on NLE

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,9 +91,8 @@ jobs:
         shell: bash
         working-directory: ./
         run: |
-          # Pin platformdirs to 4.9.4 as new version is blocked by safe-chain direct download minimum package age
-          pip install platformdirs==4.9.4
-          pip install python-discovery==1.1.3
+          # Pin virtualenv to 21.2.4 as new version is blocked by safe-chain direct download minimum package age
+          pip install virtualenv==21.2.4
           python -m pip install pre-commit
 
         # Black does not support Python 2.7 at all.

--- a/cla_frontend/apps/cla_auth/backend.py
+++ b/cla_frontend/apps/cla_auth/backend.py
@@ -20,7 +20,7 @@ from .utils import get_zone_profile
 logger = logging.getLogger(__name__)
 
 ROLES = {
-    "Civil Legal Advice - Helpline Operator Manager": {"ui": "operator", "is_manager": True},
+    "Civil Legal Advice - Operator Manager": {"ui": "operator", "is_manager": True},
     "Civil Legal Advice - Helpline Operator": {"ui": "operator", "is_manager": False},
     "Civil Legal Advice - Helpline Provider": {"ui": "provider", "is_manager": False},
 }

--- a/cla_frontend/apps/cla_auth/tests/test_backend.py
+++ b/cla_frontend/apps/cla_auth/tests/test_backend.py
@@ -266,7 +266,7 @@ class EntraBackendTestCase(SimpleTestCase):
     @mock.patch("cla_auth.backend.EntraTokenDecoder")
     def test_token_to_user_sets_is_manager_for_manager_role(self, mock_decoder_cls):
         # Arrange: the decoder's decode method returns a payload with a manager role.
-        role = "Civil Legal Advice - Helpline Operator Manager"
+        role = "Civil Legal Advice - Operator Manager"
         mock_decoder_cls.return_value.decode.return_value = {
             "preferred_username": "manager@example.com",
             "LAA_APP_ROLES": [role],


### PR DESCRIPTION
## What does this pull request do?

Update operator manager to match that of whats on NLE.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
