### PR TITLE
adding alternative help for dummy provider

### DIFF
--- a/cla_frontend/assets-src/javascripts/app/js/controllers/call_centre/assign_provider.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/call_centre/assign_provider.js
@@ -73,7 +73,7 @@
             is_spor: $scope.is_spor,
             is_urgent: $scope.is_urgent
           };
-
+   
           if ($scope.is_manual) {
             data.notes = $scope.notes;
           }
@@ -83,6 +83,11 @@
               $scope.assigning_provider_in_progress = true;
               $scope.case.$assign(data).then(
                 function(response) {
+                  if (response.data && response.data.short_code === "EDFF_DUMMY") {
+                      $state.go('case_detail.alternative_help'); 
+                      return; 
+                  }
+                      
                   $state.go('case_list');
                   $window.dataLayer.push({ 'event': 'ProviderAssigned', 'AssignedProviderId': $scope.selected_provider ? $scope.selected_provider.id : null, 'MatterType1': $scope.$parent.case ? $scope.$parent.case.matter_type1 : null, 'MatterType2': $scope.$parent.case ? $scope.$parent.case.matter_type2 : null  });
                   flash('success', 'Case ' + $scope.case.reference + ' assigned to ' + response.data.name);

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/call_centre/assign_provider.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/call_centre/assign_provider.js
@@ -73,7 +73,6 @@
             is_spor: $scope.is_spor,
             is_urgent: $scope.is_urgent
           };
-   
           if ($scope.is_manual) {
             data.notes = $scope.notes;
           }
@@ -82,13 +81,14 @@
             function () {
               $scope.assigning_provider_in_progress = true;
               $scope.case.$assign(data).then(
+               
                 function(response) {
-                  if (response.data && response.data.short_code === "EDFF_DUMMY") {
-                      $state.go('case_detail.alternative_help'); 
-                      return; 
-                  }
-                      
-                  $state.go('case_list');
+                  var goto = (response.data && response.data.short_code === "EDFF_DUMMY")
+                  ? 'case_detail.alternative_help'
+                  : 'case_list';
+                
+                  $state.go(goto);
+                  
                   $window.dataLayer.push({ 'event': 'ProviderAssigned', 'AssignedProviderId': $scope.selected_provider ? $scope.selected_provider.id : null, 'MatterType1': $scope.$parent.case ? $scope.$parent.case.matter_type1 : null, 'MatterType2': $scope.$parent.case ? $scope.$parent.case.matter_type2 : null  });
                   flash('success', 'Case ' + $scope.case.reference + ' assigned to ' + response.data.name);
                 },


### PR DESCRIPTION
[LGA-3974](https://dsdmoj.atlassian.net/browse/LGA-3974)

This PR adds a feature flag path to reroute education cases to alternative help when the configured dummy provider is selected, instead of assigning a specialist provider.

What changed
The frontend will re route when the dummy/test provider is been assign to cases
See for the rest of the development 
[https://github.com/ministryofjustice/cla_backend/pull/1394](url)

Why
This supports the provider exit by redirecting impacted education cases to FALA facing alternative help while keeping the change controlled via settings.


[LGA-3974]: https://dsdmoj.atlassian.net/browse/LGA-3974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ