### PR TITLE
LGA-4089: new XML flow for Entra users

### DIFF
--- a/cla_frontend/apps/cla_auth/backend.py
+++ b/cla_frontend/apps/cla_auth/backend.py
@@ -84,11 +84,14 @@ class EntraBackend(object):
         user = ClaUser(token, self.zone_name)
         roles = payload["LAA_APP_ROLES"] if isinstance(payload["LAA_APP_ROLES"], list) else [payload["LAA_APP_ROLES"]]
         roles = [role for role in roles if role in ROLES]
+        raw_accounts = payload.get("LAA_ACCOUNTS", [])
+        office_codes = raw_accounts if isinstance(raw_accounts, list) else [raw_accounts]
         user._me_data = {
             "username": payload["preferred_username"],
             "roles": roles,
             "is_manager": any([ROLES[role]["is_manager"] for role in roles]),
             "ui_access": [ROLES[role]["ui"] for role in roles],
+            "office_codes": office_codes,
         }
         return user
 

--- a/cla_frontend/apps/cla_auth/models.py
+++ b/cla_frontend/apps/cla_auth/models.py
@@ -37,7 +37,9 @@ class ClaUser(object):
 
     @property
     def office_codes(self):
-        return self._data.get("office_codes", [])
+        if not hasattr(self, "_me_data"):
+            return []
+        return self._me_data.get("office_codes", [])
 
     @property
     def username(self):

--- a/cla_frontend/apps/cla_auth/models.py
+++ b/cla_frontend/apps/cla_auth/models.py
@@ -36,6 +36,10 @@ class ClaUser(object):
         return self._data.get("is_manager")
 
     @property
+    def office_codes(self):
+        return self._data.get("office_codes", [])
+
+    @property
     def username(self):
         return self._data.get("username")
 

--- a/cla_frontend/apps/cla_auth/tests/test_views.py
+++ b/cla_frontend/apps/cla_auth/tests/test_views.py
@@ -312,38 +312,27 @@ class BackendProxyViewTestCase(SimpleTestCase):
         return request
 
     @mock.patch("cla_auth.views.proxy_view")
-    def test_entra_token_present_forwards_bearer_header(self, mock_proxy_view):
+    @mock.patch("cla_auth.views.get_connection")
+    def test_entra_token_present_forwards_bearer_header(self, mock_get_connection, mock_proxy_view):
+        mock_client = mock.MagicMock()
+        mock_client._store = {
+            "session": mock.MagicMock(
+                auth=mock.MagicMock(get_header=mock.Mock(return_value=("authorization", "Bearer tok123")))
+            ),
+            "base_url": "https://backend/",
+        }
+        mock_get_connection.return_value = mock_client
         request = self._make_request(session={"entra_access_token": "tok123"})
 
-        backend_proxy_view(
-            request,
-            path="caseExport/",
-            use_auth_header=False,
-            use_entra_token=True,
-            base_remote_url="https://backend/",
-        )
+        backend_proxy_view(request, path="caseExport/", base_remote_url="https://backend/")
 
         mock_proxy_view.assert_called_once_with(
-            request, "https://backend/caseExport/", {"headers": {"Authorization": "Bearer tok123"}}
+            request, "https://backend/caseExport/", {"headers": {"AUTHORIZATION": "Bearer tok123"}}
         )
-
-    @mock.patch("cla_auth.views.proxy_view")
-    def test_entra_token_absent_sends_no_auth_header(self, mock_proxy_view):
-        request = self._make_request(session={})
-
-        backend_proxy_view(
-            request,
-            path="caseExport/",
-            use_auth_header=False,
-            use_entra_token=True,
-            base_remote_url="https://backend/",
-        )
-
-        mock_proxy_view.assert_called_once_with(request, "https://backend/caseExport/", {"headers": {}})
 
     @mock.patch("cla_auth.views.proxy_view")
     @mock.patch("cla_auth.views.get_connection")
-    def test_use_auth_header_builds_headers_from_legacy_connection(self, mock_get_connection, mock_proxy_view):
+    def test_entra_token_absent_falls_back_to_legacy_connection(self, mock_get_connection, mock_proxy_view):
         mock_client = mock.MagicMock()
         mock_client._store = {
             "session": mock.MagicMock(
@@ -352,7 +341,7 @@ class BackendProxyViewTestCase(SimpleTestCase):
             "base_url": "https://legacy-base/",
         }
         mock_get_connection.return_value = mock_client
-        request = self._make_request()
+        request = self._make_request(session={})
 
         backend_proxy_view(request, path="case/ABC/")
 
@@ -360,10 +349,27 @@ class BackendProxyViewTestCase(SimpleTestCase):
             request, "https://legacy-base/case/ABC/", {"headers": {"AUTHORIZATION": "Bearer legacy-token"}}
         )
 
-    def test_raises_when_no_auth_method_or_base_url_given(self):
+    @mock.patch("cla_auth.views.proxy_view")
+    @mock.patch("cla_auth.views.get_connection")
+    def test_explicit_base_url_overrides_connection_url(self, mock_get_connection, mock_proxy_view):
+        mock_client = mock.MagicMock()
+        mock_client._store = {
+            "session": mock.MagicMock(
+                auth=mock.MagicMock(get_header=mock.Mock(return_value=("authorization", "Bearer legacy-token")))
+            ),
+            "base_url": "https://legacy-base/",
+        }
+        mock_get_connection.return_value = mock_client
+        request = self._make_request(session={})
+
+        backend_proxy_view(request, path="case/ABC/", base_remote_url="https://explicit-base/")
+
+        mock_proxy_view.assert_called_once_with(
+            request, "https://explicit-base/case/ABC/", {"headers": {"AUTHORIZATION": "Bearer legacy-token"}}
+        )
+
+    def test_raises_when_no_auth_and_no_base_url(self):
         request = self._make_request()
 
         with self.assertRaises(AssertionError):
-            backend_proxy_view(
-                request, path="caseExport/", use_auth_header=False, use_entra_token=False, base_remote_url=None
-            )
+            backend_proxy_view(request, path="caseExport/", use_auth_header=False, base_remote_url=None)

--- a/cla_frontend/apps/cla_auth/tests/test_views.py
+++ b/cla_frontend/apps/cla_auth/tests/test_views.py
@@ -320,11 +320,11 @@ class BackendProxyViewTestCase(SimpleTestCase):
             path="caseExport/",
             use_auth_header=False,
             use_entra_token=True,
-            base_remote_url="http://backend/",
+            base_remote_url="https://backend/",
         )
 
         mock_proxy_view.assert_called_once_with(
-            request, "http://backend/caseExport/", {"headers": {"Authorization": "Bearer tok123"}}
+            request, "https://backend/caseExport/", {"headers": {"Authorization": "Bearer tok123"}}
         )
 
     @mock.patch("cla_auth.views.proxy_view")
@@ -336,10 +336,10 @@ class BackendProxyViewTestCase(SimpleTestCase):
             path="caseExport/",
             use_auth_header=False,
             use_entra_token=True,
-            base_remote_url="http://backend/",
+            base_remote_url="https://backend/",
         )
 
-        mock_proxy_view.assert_called_once_with(request, "http://backend/caseExport/", {"headers": {}})
+        mock_proxy_view.assert_called_once_with(request, "https://backend/caseExport/", {"headers": {}})
 
     @mock.patch("cla_auth.views.proxy_view")
     @mock.patch("cla_auth.views.get_connection")
@@ -349,7 +349,7 @@ class BackendProxyViewTestCase(SimpleTestCase):
             "session": mock.MagicMock(
                 auth=mock.MagicMock(get_header=mock.Mock(return_value=("authorization", "Bearer legacy-token")))
             ),
-            "base_url": "http://legacy-base/",
+            "base_url": "https://legacy-base/",
         }
         mock_get_connection.return_value = mock_client
         request = self._make_request()
@@ -357,7 +357,7 @@ class BackendProxyViewTestCase(SimpleTestCase):
         backend_proxy_view(request, path="case/ABC/")
 
         mock_proxy_view.assert_called_once_with(
-            request, "http://legacy-base/case/ABC/", {"headers": {"AUTHORIZATION": "Bearer legacy-token"}}
+            request, "https://legacy-base/case/ABC/", {"headers": {"AUTHORIZATION": "Bearer legacy-token"}}
         )
 
     def test_raises_when_no_auth_method_or_base_url_given(self):

--- a/cla_frontend/apps/cla_auth/tests/test_views.py
+++ b/cla_frontend/apps/cla_auth/tests/test_views.py
@@ -4,7 +4,7 @@ from slumber.exceptions import HttpClientError
 
 from django.test.testcases import SimpleTestCase
 from django.test import override_settings, RequestFactory
-from cla_auth.views import EntraAuthView
+from cla_auth.views import EntraAuthView, backend_proxy_view
 from django.core.urlresolvers import reverse
 from django.contrib.auth import REDIRECT_FIELD_NAME, SESSION_KEY, BACKEND_SESSION_KEY
 
@@ -300,3 +300,70 @@ class EntraRouteCallBackTestCase(SimpleTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("/some/next/url", response["Location"])
         self.assertNotIn(REDIRECT_FIELD_NAME, request.session)
+
+
+class BackendProxyViewTestCase(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _make_request(self, session=None):
+        request = self.factory.post("/proxy/caseExport/")
+        request.session = session if session is not None else {}
+        return request
+
+    @mock.patch("cla_auth.views.proxy_view")
+    def test_entra_token_present_forwards_bearer_header(self, mock_proxy_view):
+        request = self._make_request(session={"entra_access_token": "tok123"})
+
+        backend_proxy_view(
+            request,
+            path="caseExport/",
+            use_auth_header=False,
+            use_entra_token=True,
+            base_remote_url="http://backend/",
+        )
+
+        mock_proxy_view.assert_called_once_with(
+            request, "http://backend/caseExport/", {"headers": {"Authorization": "Bearer tok123"}}
+        )
+
+    @mock.patch("cla_auth.views.proxy_view")
+    def test_entra_token_absent_sends_no_auth_header(self, mock_proxy_view):
+        request = self._make_request(session={})
+
+        backend_proxy_view(
+            request,
+            path="caseExport/",
+            use_auth_header=False,
+            use_entra_token=True,
+            base_remote_url="http://backend/",
+        )
+
+        mock_proxy_view.assert_called_once_with(request, "http://backend/caseExport/", {"headers": {}})
+
+    @mock.patch("cla_auth.views.proxy_view")
+    @mock.patch("cla_auth.views.get_connection")
+    def test_use_auth_header_builds_headers_from_legacy_connection(self, mock_get_connection, mock_proxy_view):
+        mock_client = mock.MagicMock()
+        mock_client._store = {
+            "session": mock.MagicMock(
+                auth=mock.MagicMock(get_header=mock.Mock(return_value=("authorization", "Bearer legacy-token")))
+            ),
+            "base_url": "http://legacy-base/",
+        }
+        mock_get_connection.return_value = mock_client
+        request = self._make_request()
+
+        backend_proxy_view(request, path="case/ABC/")
+
+        mock_proxy_view.assert_called_once_with(
+            request, "http://legacy-base/case/ABC/", {"headers": {"AUTHORIZATION": "Bearer legacy-token"}}
+        )
+
+    def test_raises_when_no_auth_method_or_base_url_given(self):
+        request = self._make_request()
+
+        with self.assertRaises(AssertionError):
+            backend_proxy_view(
+                request, path="caseExport/", use_auth_header=False, use_entra_token=False, base_remote_url=None
+            )

--- a/cla_frontend/apps/cla_auth/views.py
+++ b/cla_frontend/apps/cla_auth/views.py
@@ -213,7 +213,7 @@ def _handle_password_step(request, template_name, redirect_to):
 # LEGACY VIEWS - to be removed once we have fully switched to Entra ID authentication
 # ==============================================================
 @csrf_exempt
-def backend_proxy_view(request, path, use_auth_header=True, base_remote_url=None):
+def backend_proxy_view(request, path, use_auth_header=True, use_entra_token=False, base_remote_url=None):
     """
     TODO: hacky as it's getting the base_url and the auth header from the
         get_connection slumber object.
@@ -223,8 +223,11 @@ def backend_proxy_view(request, path, use_auth_header=True, base_remote_url=None
     if you specifiy `use_auth_header` to be false, then it won't use the zone
     or url info from the get_connection slumber object. In that case you
     should pass in the base_remote_url yourself.
+
+    if you specify `use_entra_token` to be true, the Entra access token stored
+    in the session will be forwarded as a Bearer token to the remote endpoint.
     """
-    assert use_auth_header or base_remote_url
+    assert use_auth_header or use_entra_token or base_remote_url
     if use_auth_header:
         client = get_connection(request)
         extra_requests_args = {
@@ -232,6 +235,11 @@ def backend_proxy_view(request, path, use_auth_header=True, base_remote_url=None
         }
         if not base_remote_url:
             base_remote_url = client._store["base_url"]
+    elif use_entra_token:
+        token = request.session.get("entra_access_token")
+        extra_requests_args = {
+            "headers": {"Authorization": "Bearer %s" % token} if token else {}
+        }
     else:
         extra_requests_args = {}
     remoteurl = "%s%s" % (base_remote_url, path)

--- a/cla_frontend/apps/cla_auth/views.py
+++ b/cla_frontend/apps/cla_auth/views.py
@@ -213,7 +213,7 @@ def _handle_password_step(request, template_name, redirect_to):
 # LEGACY VIEWS - to be removed once we have fully switched to Entra ID authentication
 # ==============================================================
 @csrf_exempt
-def backend_proxy_view(request, path, use_auth_header=True, use_entra_token=False, base_remote_url=None):
+def backend_proxy_view(request, path, use_auth_header=True, base_remote_url=None):
     """
     TODO: hacky as it's getting the base_url and the auth header from the
         get_connection slumber object.
@@ -223,11 +223,8 @@ def backend_proxy_view(request, path, use_auth_header=True, use_entra_token=Fals
     if you specifiy `use_auth_header` to be false, then it won't use the zone
     or url info from the get_connection slumber object. In that case you
     should pass in the base_remote_url yourself.
-
-    if you specify `use_entra_token` to be true, the Entra access token stored
-    in the session will be forwarded as a Bearer token to the remote endpoint.
     """
-    assert use_auth_header or use_entra_token or base_remote_url
+    assert use_auth_header or base_remote_url
     if use_auth_header:
         client = get_connection(request)
         extra_requests_args = {
@@ -235,11 +232,6 @@ def backend_proxy_view(request, path, use_auth_header=True, use_entra_token=Fals
         }
         if not base_remote_url:
             base_remote_url = client._store["base_url"]
-    elif use_entra_token:
-        token = request.session.get("entra_access_token")
-        extra_requests_args = {
-            "headers": {"Authorization": "Bearer %s" % token} if token else {}
-        }
     else:
         extra_requests_args = {}
     remoteurl = "%s%s" % (base_remote_url, path)

--- a/cla_frontend/apps/cla_provider/tests/test_views.py
+++ b/cla_frontend/apps/cla_provider/tests/test_views.py
@@ -246,26 +246,41 @@ class LegalHelpFormTestCase(CLATFrontEndTestCase):
 
 
 class GetEnabledFeatureFlagsTestCase(SimpleTestCase):
-    @override_settings(XML_EXPORT_BUTTON_FEATURE_FLAG=True)
-    def test_xml_export_button_enabled(self):
-        self.assertEqual(get_enabled_feature_flags(), ["xml_export_button"])
+    def _make_user(self, office_codes):
+        user = mock.MagicMock()
+        user.office_codes = office_codes
+        return user
 
-    @override_settings(XML_EXPORT_BUTTON_FEATURE_FLAG=False)
-    def test_xml_export_button_disabled(self):
-        self.assertEqual(get_enabled_feature_flags(), [])
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01", "B02"])
+    def test_xml_export_button_enabled_for_matching_office(self):
+        self.assertEqual(get_enabled_feature_flags(self._make_user(["B01"])), ["xml_export_button"])
+
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01", "B02"])
+    def test_xml_export_button_disabled_for_non_matching_office(self):
+        self.assertEqual(get_enabled_feature_flags(self._make_user(["X99"])), [])
+
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=[])
+    def test_xml_export_button_disabled_when_no_offices_configured(self):
+        self.assertEqual(get_enabled_feature_flags(self._make_user(["B01"])), [])
+
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"])
+    def test_xml_export_button_disabled_when_user_has_no_accounts(self):
+        self.assertEqual(get_enabled_feature_flags(self._make_user([])), [])
 
 
 class DashboardFeatureFlagsTestCase(CLATFrontEndTestCase):
     zone = "cla_provider"
 
-    @override_settings(XML_EXPORT_BUTTON_FEATURE_FLAG=True)
-    def test_cla_features_in_context_when_enabled(self):
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"])
+    @mock.patch("cla_provider.views.get_enabled_feature_flags", return_value=["xml_export_button"])
+    def test_cla_features_in_context_when_enabled(self, _):
         self.login()
         response = self.client.get(reverse("cla_provider:dashboard"))
         self.assertIn("xml_export_button", response.context["cla_features"])
 
-    @override_settings(XML_EXPORT_BUTTON_FEATURE_FLAG=False)
-    def test_cla_features_in_context_when_disabled(self):
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=[])
+    @mock.patch("cla_provider.views.get_enabled_feature_flags", return_value=[])
+    def test_cla_features_in_context_when_disabled(self, _):
         self.login()
         response = self.client.get(reverse("cla_provider:dashboard"))
         self.assertNotIn("xml_export_button", response.context["cla_features"])

--- a/cla_frontend/apps/cla_provider/tests/test_views.py
+++ b/cla_frontend/apps/cla_provider/tests/test_views.py
@@ -2,11 +2,12 @@ import mock
 
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from slumber.exceptions import HttpClientError
 
 from cla_common.constants import DISREGARDS, SPECIFIC_BENEFITS
 
+from cla_provider.views import get_enabled_feature_flags
 from core.testing.test_base import CLATFrontEndTestCase
 
 
@@ -242,3 +243,29 @@ class LegalHelpFormTestCase(CLATFrontEndTestCase):
             },
             {},
         )
+
+
+class GetEnabledFeatureFlagsTestCase(SimpleTestCase):
+    @override_settings(XML_EXPORT_BUTTON_FEATURE_FLAG=True)
+    def test_xml_export_button_enabled(self):
+        self.assertEqual(get_enabled_feature_flags(), ["xml_export_button"])
+
+    @override_settings(XML_EXPORT_BUTTON_FEATURE_FLAG=False)
+    def test_xml_export_button_disabled(self):
+        self.assertEqual(get_enabled_feature_flags(), [])
+
+
+class DashboardFeatureFlagsTestCase(CLATFrontEndTestCase):
+    zone = "cla_provider"
+
+    @override_settings(XML_EXPORT_BUTTON_FEATURE_FLAG=True)
+    def test_cla_features_in_context_when_enabled(self):
+        self.login()
+        response = self.client.get(reverse("cla_provider:dashboard"))
+        self.assertIn("xml_export_button", response.context["cla_features"])
+
+    @override_settings(XML_EXPORT_BUTTON_FEATURE_FLAG=False)
+    def test_cla_features_in_context_when_disabled(self):
+        self.login()
+        response = self.client.get(reverse("cla_provider:dashboard"))
+        self.assertNotIn("xml_export_button", response.context["cla_features"])

--- a/cla_frontend/apps/cla_provider/urls.py
+++ b/cla_frontend/apps/cla_provider/urls.py
@@ -23,7 +23,7 @@ urlpatterns = patterns(
         r"^proxy/caseExport/$",
         auth_views.backend_proxy_view,
         name="backend_proxy_provider_export",
-        kwargs={"use_auth_header": False, "use_entra_token": True, "path": "caseExport/", "base_remote_url": zone.get("BASE_URI")},
+        kwargs={"use_auth_header": True, "path": "caseExport/", "base_remote_url": zone.get("BASE_URI")},
     ),
     url(r"^proxy/(?P<path>.*)", auth_views.backend_proxy_view, name="backend_proxy"),
     url(r"^.*$", views.dashboard, name="dashboard"),

--- a/cla_frontend/apps/cla_provider/urls.py
+++ b/cla_frontend/apps/cla_provider/urls.py
@@ -19,12 +19,7 @@ urlpatterns = patterns(
     url(r"^login/$", RedirectView.as_view(url=reverse_lazy("auth:login")), name="login"),
     url(r"^case/(?P<case_reference>.+)/legal_help_form/$", provider_views.legal_help_form, name="legal_help_form"),
     url(r"^zendesk/$", cla_provider_zone_required(ZendeskView.as_view()), name="zendesk"),
-    url(
-        r"^proxy/caseExport/$",
-        auth_views.backend_proxy_view,
-        name="backend_proxy_provider_export",
-        kwargs={"use_auth_header": True, "path": "caseExport/", "base_remote_url": zone.get("BASE_URI")},
-    ),
+    url(r"^proxy/caseExport/$", views.case_export_proxy, name="backend_proxy_provider_export"),
     url(r"^proxy/(?P<path>.*)", auth_views.backend_proxy_view, name="backend_proxy"),
     url(r"^.*$", views.dashboard, name="dashboard"),
 )

--- a/cla_frontend/apps/cla_provider/urls.py
+++ b/cla_frontend/apps/cla_provider/urls.py
@@ -23,7 +23,7 @@ urlpatterns = patterns(
         r"^proxy/caseExport/$",
         auth_views.backend_proxy_view,
         name="backend_proxy_provider_export",
-        kwargs={"use_auth_header": False, "path": "caseExport/", "base_remote_url": zone.get("BASE_URI")},
+        kwargs={"use_auth_header": False, "use_entra_token": True, "path": "caseExport/", "base_remote_url": zone.get("BASE_URI")},
     ),
     url(r"^proxy/(?P<path>.*)", auth_views.backend_proxy_view, name="backend_proxy"),
     url(r"^.*$", views.dashboard, name="dashboard"),

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -1,11 +1,13 @@
 from django.shortcuts import render
 from django.http.response import HttpResponse
 from django.conf import settings
+from django.views.decorators.csrf import csrf_exempt
 
 from api.client import get_connection
 
 from slumber.exceptions import HttpClientError
 from cla_auth.utils import cla_provider_zone_required
+from cla_auth.views import backend_proxy_view
 
 from cla_common.constants import DISREGARDS, SPECIFIC_BENEFITS
 
@@ -21,6 +23,18 @@ def get_enabled_feature_flags(user):
         "xml_export_button": bool(allowed_offices) and any(code in allowed_offices for code in user.office_codes)
     }
     return [name for name, value in flags.items() if value]
+
+
+@csrf_exempt
+@cla_provider_zone_required
+def case_export_proxy(request):
+    zone = settings.ZONE_PROFILES.get("cla_provider", {})
+    return backend_proxy_view(
+        request,
+        path="caseExport/",
+        use_auth_header="xml_export_button" in get_enabled_feature_flags(request.user),
+        base_remote_url=zone.get("BASE_URI"),
+    )
 
 
 @cla_provider_zone_required

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -20,7 +20,7 @@ def dashboard(request):
 def get_enabled_feature_flags(user):
     allowed_offices = settings.XML_EXPORT_BUTTON_OFFICE_CODES
     flags = {
-        "xml_export_button": bool(allowed_offices) and any(code in allowed_offices for code in user.office_codes)
+        "xml_export_button": any(code in allowed_offices for code in user.office_codes)
     }
     return [name for name, value in flags.items() if value]
 

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -12,11 +12,14 @@ from cla_common.constants import DISREGARDS, SPECIFIC_BENEFITS
 
 @cla_provider_zone_required
 def dashboard(request):
-    return render(request, "cla_provider/angular_app.html", {"cla_features": get_enabled_feature_flags()})
+    return render(request, "cla_provider/angular_app.html", {"cla_features": get_enabled_feature_flags(request.user)})
 
 
-def get_enabled_feature_flags():
-    flags = {"xml_export_button": settings.XML_EXPORT_BUTTON_FEATURE_FLAG}
+def get_enabled_feature_flags(user):
+    allowed_offices = settings.XML_EXPORT_BUTTON_OFFICE_CODES
+    flags = {
+        "xml_export_button": bool(allowed_offices) and any(code in allowed_offices for code in user.office_codes)
+    }
     return [name for name, value in flags.items() if value]
 
 

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.http.response import HttpResponse
+from django.conf import settings
 
 from api.client import get_connection
 
@@ -11,7 +12,12 @@ from cla_common.constants import DISREGARDS, SPECIFIC_BENEFITS
 
 @cla_provider_zone_required
 def dashboard(request):
-    return render(request, "cla_provider/angular_app.html", {})
+    return render(request, "cla_provider/angular_app.html", {"cla_features": get_enabled_feature_flags()})
+
+
+def get_enabled_feature_flags():
+    flags = {"xml_export_button": settings.XML_EXPORT_BUTTON_FEATURE_FLAG}
+    return [name for name, value in flags.items() if value]
 
 
 @cla_provider_zone_required

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/provider/accept_reject_case.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/provider/accept_reject_case.js
@@ -2,8 +2,11 @@
   'use strict';
 
   angular.module('cla.controllers.provider').
-    controller('AcceptRejectCaseCtrl', ['$scope', '$uibModal', 'flash', 'postal', '$state', '$window',
-    function($scope, $uibModal, flash, postal, $state, $window){
+    controller('AcceptRejectCaseCtrl', ['$scope', '$uibModal', 'flash', 'postal', '$state', '$window', 'ClaFeatures',
+    function($scope, $uibModal, flash, postal, $state, $window, ClaFeatures){
+      $scope.userIsEntra = document.head.dataset.userIsEntra === 'true';
+      $scope.xmlExportButton = ClaFeatures.is_feature_enabled('xml_export_button');
+
       $scope.showDebtReferralButton = function() {
         if (!$scope.case.provider_accepted || $scope.case.provider_closed) {
           return false;
@@ -108,6 +111,20 @@
               return Category.query().$promise;
             }]
           }
+        });
+      };
+
+      $scope.exportXml = function() {
+        $scope.case.$export_xml().then(function(response) {
+          var blob = new Blob([response.data], { type: 'application/xml' });
+          var downloadUrl = $window.URL.createObjectURL(blob);
+          var a = document.createElement('a');
+          a.href = downloadUrl;
+          a.download = $scope.case.reference + '.xml';
+          a.click();
+          $window.URL.revokeObjectURL(downloadUrl);
+        }, function() {
+          flash('error', 'There was a problem exporting this case');
         });
       };
     }]

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/provider/accept_reject_case.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/provider/accept_reject_case.js
@@ -123,9 +123,42 @@
           a.download = $scope.case.reference + '.xml';
           a.click();
           $window.URL.revokeObjectURL(downloadUrl);
-        }, function() {
-          flash('error', 'There was a problem exporting this case');
+        }, function(rejection) {
+          if (rejection.status === 401) {
+            flash('error', 'Your session has expired. Please sign in again.');
+          } else if (rejection.status === 403) {
+            flash('error', 'You do not have permission to export this case.');
+          } else if (rejection.status === 404) {
+            flash('error', 'Case ' + $scope.case.reference + ' could not be found.');
+          } else if (rejection.status === 400) {
+            readBlobAsText(rejection.data, function(text) {
+              flash('error', parseValidationErrors(text));
+            });
+          } else {
+            flash('error', 'There was a problem exporting this case.');
+          }
         });
+      };
+
+      var readBlobAsText = function(blob, callback) {
+        var reader = new FileReader();
+        reader.onload = function() { callback(reader.result); };
+        reader.onerror = function() { callback(''); };
+        reader.readAsText(blob);
+      };
+
+      var parseValidationErrors = function(text) {
+        var fallback = 'There was a problem with the export request.';
+        try {
+          var errors = JSON.parse(text);
+          var fieldErrors = [];
+          angular.forEach(errors, function(messages, field) {
+            fieldErrors.push(field + ': ' + (angular.isArray(messages) ? messages.join(', ') : messages));
+          });
+          return fieldErrors.length ? fieldErrors.join('; ') : fallback;
+        } catch (e) {
+          return fallback;
+        }
       };
     }]
   );

--- a/cla_frontend/assets-src/javascripts/app/js/controllers/provider/accept_reject_case.js
+++ b/cla_frontend/assets-src/javascripts/app/js/controllers/provider/accept_reject_case.js
@@ -123,42 +123,19 @@
           a.download = $scope.case.reference + '.xml';
           a.click();
           $window.URL.revokeObjectURL(downloadUrl);
-        }, function(rejection) {
-          if (rejection.status === 401) {
+        }, function(error_) {
+          if (error_.status === 401) {
             flash('error', 'Your session has expired. Please sign in again.');
-          } else if (rejection.status === 403) {
+          } else if (error_.status === 403) {
             flash('error', 'You do not have permission to export this case.');
-          } else if (rejection.status === 404) {
+          } else if (error_.status === 404) {
             flash('error', 'Case ' + $scope.case.reference + ' could not be found.');
-          } else if (rejection.status === 400) {
-            readBlobAsText(rejection.data, function(text) {
-              flash('error', parseValidationErrors(text));
-            });
+          } else if (error_.status === 400) {
+            flash('error', 'There was a problem with the export request.');
           } else {
             flash('error', 'There was a problem exporting this case.');
           }
         });
-      };
-
-      var readBlobAsText = function(blob, callback) {
-        var reader = new FileReader();
-        reader.onload = function() { callback(reader.result); };
-        reader.onerror = function() { callback(''); };
-        reader.readAsText(blob);
-      };
-
-      var parseValidationErrors = function(text) {
-        var fallback = 'There was a problem with the export request.';
-        try {
-          var errors = JSON.parse(text);
-          var fieldErrors = [];
-          angular.forEach(errors, function(messages, field) {
-            fieldErrors.push(field + ': ' + (angular.isArray(messages) ? messages.join(', ') : messages));
-          });
-          return fieldErrors.length ? fieldErrors.join('; ') : fallback;
-        } catch (e) {
-          return fallback;
-        }
       };
     }]
   );

--- a/cla_frontend/assets-src/javascripts/app/js/services/models.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/models.js
@@ -96,6 +96,17 @@
         }
       );
 
+      resource.prototype.$export_xml = function () {
+        return $http.post(
+          url_utils.proxy('caseExport/'),
+          $.param({CHSCRN: this.reference}),
+          {
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            responseType: 'blob'
+          }
+        );
+      };
+
       resource.prototype.$defer_assignment = function(data) {
         var url = url_utils.proxy('case/'+this.reference+'/defer_assignment/');
         return $http.post(url, data);

--- a/cla_frontend/assets-src/javascripts/app/js/services/models.js
+++ b/cla_frontend/assets-src/javascripts/app/js/services/models.js
@@ -102,7 +102,8 @@
           $.param({CHSCRN: this.reference}),
           {
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            responseType: 'blob'
+            responseType: 'blob',
+            ignoreExceptions: [400, 401, 403, 404]
           }
         );
       };

--- a/cla_frontend/assets-src/javascripts/app/partials/provider/case_detail.html
+++ b/cla_frontend/assets-src/javascripts/app/partials/provider/case_detail.html
@@ -9,6 +9,8 @@
 
     <button class="BtnGroup-button BtnGroup-button--light" name="split-case" ng-click="split()" ng-if="!case.provider_closed">Split</button>
 
+    <button class="BtnGroup-button BtnGroup-button--light" name="export-case" ng-click="exportXml()" ng-if="userIsEntra && xmlExportButton">Export XML</button>
+
     <a href="/provider/case/{{ case.reference }}/legal_help_form/" target="_self" class="BtnGroup-button BtnGroup-button--light" ng-if="case.provider_accepted || case.provider_closed">Legal help form</a>
 
     <button class="BtnGroup-button BtnGroup-button--light" name="provider-close-case" ng-click="close()" ng-controller="CaseDetailCloseCtrl" ng-if="case.provider_accepted && !case.provider_closed">Close</button>

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -182,8 +182,12 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 # Sets whether the updated family issue text displays on in scope family cases or not
 FAMILY_ISSUE_FEATURE_FLAG = os.environ.get("FAMILY_ISSUE_FEATURE_FLAG", "False").lower() == "true"
 
-# Sets whether the Export XML button is shown on the provider case screen
-XML_EXPORT_BUTTON_FEATURE_FLAG = os.environ.get("XML_EXPORT_BUTTON_FEATURE_FLAG", "False").lower() == "true"
+# Office codes allowed to see the Export XML button. Empty list disables the button for all.
+XML_EXPORT_BUTTON_OFFICE_CODES = [
+    code.strip()
+    for code in os.environ.get("XML_EXPORT_BUTTON_OFFICE_CODES", "").split(",")
+    if code.strip()
+]
 
 # Sets whether the new notes format is displayed
 NEW_CLIENT_NOTE_FEATURE_FLAG = os.environ.get("NEW_CLIENT_NOTE_FEATURE_FLAG", "False").lower() == "true"

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -183,7 +183,7 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 FAMILY_ISSUE_FEATURE_FLAG = os.environ.get("FAMILY_ISSUE_FEATURE_FLAG", "False").lower() == "true"
 
 # Sets whether the Export XML button is shown on the provider case screen
-XML_EXPORT_BUTTON_FEATURE_FLAG = os.environ.get("XML_EXPORT_BUTTON_FEATURE_FLAG", "True").lower() == "true"
+XML_EXPORT_BUTTON_FEATURE_FLAG = os.environ.get("XML_EXPORT_BUTTON_FEATURE_FLAG", "False").lower() == "true"
 
 # Sets whether the new notes format is displayed
 NEW_CLIENT_NOTE_FEATURE_FLAG = os.environ.get("NEW_CLIENT_NOTE_FEATURE_FLAG", "False").lower() == "true"

--- a/cla_frontend/settings/base.py
+++ b/cla_frontend/settings/base.py
@@ -182,6 +182,9 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 # Sets whether the updated family issue text displays on in scope family cases or not
 FAMILY_ISSUE_FEATURE_FLAG = os.environ.get("FAMILY_ISSUE_FEATURE_FLAG", "False").lower() == "true"
 
+# Sets whether the Export XML button is shown on the provider case screen
+XML_EXPORT_BUTTON_FEATURE_FLAG = os.environ.get("XML_EXPORT_BUTTON_FEATURE_FLAG", "True").lower() == "true"
+
 # Sets whether the new notes format is displayed
 NEW_CLIENT_NOTE_FEATURE_FLAG = os.environ.get("NEW_CLIENT_NOTE_FEATURE_FLAG", "False").lower() == "true"
 

--- a/helm_deploy/cla-frontend/values.yaml
+++ b/helm_deploy/cla-frontend/values.yaml
@@ -176,7 +176,7 @@ envVars:
     secret:
       name: sso
       key: backend_scope
-  XML_EXPORT_BUTTON_FEATURE_FLAG:
+  XML_EXPORT_BUTTON_OFFICE_CODES:
     configmap:
       name: xml-export-button
-      key: enabled
+      key: office_codes

--- a/helm_deploy/cla-frontend/values.yaml
+++ b/helm_deploy/cla-frontend/values.yaml
@@ -176,3 +176,7 @@ envVars:
     secret:
       name: sso
       key: backend_scope
+  XML_EXPORT_BUTTON_FEATURE_FLAG:
+    configmap:
+      name: xml-export-button
+      key: enabled


### PR DESCRIPTION
## What does this pull request do?

**Ticket**: https://dsdmoj.atlassian.net/browse/LGA-4089

[This is the backend part](https://github.com/ministryofjustice/cla_backend/pull/1433) of the ticket

### Summary
This PR adds a new **Export XML** button to the provider case detail page, allowing authenticated provider users to download case data as XML directly from the UI.

### Frontend changes
Added **Export XML** button to `provider/case_detail.html`
Added `$export_case()` method to the Case service and `exportCase()` to `AcceptRejectCaseCtrl`
Updated `backend_proxy_view` to inject the Entra token from the session cookie as an `Authorization: Bearer` header when calling the backend — this is the `use_auth_header` parameter, set to True for the `caseExport/` route

### Notes on legacy users
Legacy CHS users are unaffected. Their session contains no `entra_access_token`, so no Bearer header is added by the proxy, and the backend falls through to `LegacyCHSAuthentication` as before — reading `CHSUserName` and `CHSPassword` from the POST body. The **Export XML** button will not work for legacy users until they are migrated to Entra.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
