### PR TITLE
Infra: add Dockerfile param to specify file for socket-server build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
       ECR_REPOSITORY:
         required: true
         type: string
+      DOCKERFILE:
+        required: false
+        type: string
+        default: Dockerfile
     secrets:
       ECR_ROLE_TO_ASSUME:
         required: true
@@ -65,6 +69,7 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
+          file: ${{ inputs.DOCKERFILE }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -50,6 +50,7 @@ jobs:
     with:
       ECR_REGION: ${{vars.CLA_FRONTEND_ECR_REGION}}
       ECR_REPOSITORY: ${{ vars.SOCKET_SERVER_ECR_REPOSITORY }}
+      DOCKERFILE: cla_socketserver/Dockerfile
     secrets:
       ECR_ROLE_TO_ASSUME: ${{ secrets.SOCKET_SERVER_ECR_ROLE_TO_ASSUME }}
 

--- a/helm_deploy/cla-frontend/templates/socket-server-deployment.yaml
+++ b/helm_deploy/cla-frontend/templates/socket-server-deployment.yaml
@@ -41,8 +41,3 @@ spec:
           env:
             - name: SITE_HOSTNAME
               value: "{{ .Values.host }}"
-            - name: SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: secret
-                  key: value

--- a/helm_deploy/cla-frontend/templates/socket-server-deployment.yaml
+++ b/helm_deploy/cla-frontend/templates/socket-server-deployment.yaml
@@ -41,3 +41,8 @@ spec:
           env:
             - name: SITE_HOSTNAME
               value: "{{ .Values.host }}"
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: secret
+                  key: value


### PR DESCRIPTION
## What does this pull request do?

`cla_socketserver` deployment was using the root `Dockerfile` instead of the one in `cla_socketserver/Dockerfile` so to avoid that I've introduced an optional parameter `DOCKERFILE` to the build pipeline.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
