### PR TITLE
Fix: update export proxy endpoint to still allow legacy flow

### DIFF
--- a/cla_frontend/apps/cla_provider/tests/test_views.py
+++ b/cla_frontend/apps/cla_provider/tests/test_views.py
@@ -2,6 +2,7 @@ import mock
 
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.test import SimpleTestCase, override_settings, RequestFactory
 from slumber.exceptions import HttpClientError
 
@@ -285,6 +286,16 @@ class CaseExportProxyTestCase(SimpleTestCase):
             del request.user._me_data
             request.user.office_codes = []
         return request
+
+    @mock.patch("cla_provider.views.backend_proxy_view")
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
+    def test_unauthenticated_request_skips_auth_header(self, mock_proxy):
+        request = self.factory.post("/proxy/caseExport/")
+        request.zone = {}
+        request.user = AnonymousUser()
+        case_export_proxy(request)
+        _, kwargs = mock_proxy.call_args
+        self.assertFalse(kwargs["use_auth_header"])
 
     @mock.patch("cla_provider.views.backend_proxy_view")
     @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})

--- a/cla_frontend/apps/cla_provider/tests/test_views.py
+++ b/cla_frontend/apps/cla_provider/tests/test_views.py
@@ -299,11 +299,11 @@ class CaseExportProxyTestCase(SimpleTestCase):
 
     @mock.patch("cla_provider.views.backend_proxy_view")
     @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
-    def test_legacy_user_always_uses_auth_header(self, mock_proxy):
+    def test_legacy_user_skips_auth_header(self, mock_proxy):
         request = self._make_request(has_me_data=False)
         case_export_proxy(request)
         _, kwargs = mock_proxy.call_args
-        self.assertTrue(kwargs["use_auth_header"])
+        self.assertFalse(kwargs["use_auth_header"])
 
     @mock.patch("cla_provider.views.backend_proxy_view")
     @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})

--- a/cla_frontend/apps/cla_provider/tests/test_views.py
+++ b/cla_frontend/apps/cla_provider/tests/test_views.py
@@ -2,12 +2,12 @@ import mock
 
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, override_settings, RequestFactory
 from slumber.exceptions import HttpClientError
 
 from cla_common.constants import DISREGARDS, SPECIFIC_BENEFITS
 
-from cla_provider.views import get_enabled_feature_flags
+from cla_provider.views import get_enabled_feature_flags, case_export_proxy
 from core.testing.test_base import CLATFrontEndTestCase
 
 
@@ -266,6 +266,49 @@ class GetEnabledFeatureFlagsTestCase(SimpleTestCase):
     @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"])
     def test_xml_export_button_disabled_when_user_has_no_accounts(self):
         self.assertEqual(get_enabled_feature_flags(self._make_user([])), [])
+
+
+class CaseExportProxyTestCase(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _make_request(self, has_me_data=False, office_codes=None):
+        request = self.factory.post("/proxy/caseExport/")
+        request.zone = {}
+        request.user = mock.MagicMock()
+        request.user.is_authenticated.return_value = True
+        request.user.zone_to_ui.return_value = ["provider"]
+        if has_me_data:
+            request.user._me_data = {"office_codes": office_codes or []}
+            request.user.office_codes = office_codes or []
+        else:
+            del request.user._me_data
+            request.user.office_codes = []
+        return request
+
+    @mock.patch("cla_provider.views.backend_proxy_view")
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
+    def test_legacy_user_always_uses_auth_header(self, mock_proxy):
+        request = self._make_request(has_me_data=False)
+        case_export_proxy(request)
+        _, kwargs = mock_proxy.call_args
+        self.assertTrue(kwargs["use_auth_header"])
+
+    @mock.patch("cla_provider.views.backend_proxy_view")
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
+    def test_entra_user_allowed_office_uses_auth_header(self, mock_proxy):
+        request = self._make_request(has_me_data=True, office_codes=["B01"])
+        case_export_proxy(request)
+        _, kwargs = mock_proxy.call_args
+        self.assertTrue(kwargs["use_auth_header"])
+
+    @mock.patch("cla_provider.views.backend_proxy_view")
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
+    def test_entra_user_disallowed_office_skips_auth_header(self, mock_proxy):
+        request = self._make_request(has_me_data=True, office_codes=["X99"])
+        case_export_proxy(request)
+        _, kwargs = mock_proxy.call_args
+        self.assertFalse(kwargs["use_auth_header"])
 
 
 class DashboardFeatureFlagsTestCase(CLATFrontEndTestCase):

--- a/cla_frontend/apps/cla_provider/tests/test_views.py
+++ b/cla_frontend/apps/cla_provider/tests/test_views.py
@@ -288,7 +288,7 @@ class CaseExportProxyTestCase(SimpleTestCase):
         return request
 
     @mock.patch("cla_provider.views.backend_proxy_view")
-    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "https://backend/"}})
     def test_unauthenticated_request_skips_auth_header(self, mock_proxy):
         request = self.factory.post("/proxy/caseExport/")
         request.zone = {}
@@ -298,7 +298,7 @@ class CaseExportProxyTestCase(SimpleTestCase):
         self.assertFalse(kwargs["use_auth_header"])
 
     @mock.patch("cla_provider.views.backend_proxy_view")
-    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "https://backend/"}})
     def test_legacy_user_skips_auth_header(self, mock_proxy):
         request = self._make_request(has_me_data=False)
         case_export_proxy(request)
@@ -306,7 +306,7 @@ class CaseExportProxyTestCase(SimpleTestCase):
         self.assertFalse(kwargs["use_auth_header"])
 
     @mock.patch("cla_provider.views.backend_proxy_view")
-    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "https://backend/"}})
     def test_entra_user_allowed_office_uses_auth_header(self, mock_proxy):
         request = self._make_request(has_me_data=True, office_codes=["B01"])
         case_export_proxy(request)
@@ -314,7 +314,7 @@ class CaseExportProxyTestCase(SimpleTestCase):
         self.assertTrue(kwargs["use_auth_header"])
 
     @mock.patch("cla_provider.views.backend_proxy_view")
-    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "http://backend/"}})
+    @override_settings(XML_EXPORT_BUTTON_OFFICE_CODES=["B01"], ZONE_PROFILES={"cla_provider": {"BASE_URI": "https://backend/"}})
     def test_entra_user_disallowed_office_skips_auth_header(self, mock_proxy):
         request = self._make_request(has_me_data=True, office_codes=["X99"])
         case_export_proxy(request)

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -24,14 +24,19 @@ def get_enabled_feature_flags(user):
     }
     return [name for name, value in flags.items() if value]
 
+# ============================================================================
+# TODO: This proxy view allows legacy user to still use the old XML export flow. 
+# Update accordingly once SiLAS is fully implemented and the legacy flow is deprecated.
+# ============================================================================
+
 
 @csrf_exempt
 def case_export_proxy(request):
     zone = settings.ZONE_PROFILES.get("cla_provider", {})
     is_authenticated = getattr(request.user, "is_authenticated", lambda: False)()
     if is_authenticated:
-        is_entra_user = hasattr(request.user, "_me_data")
-        use_auth_header = is_entra_user and "xml_export_button" in get_enabled_feature_flags(request.user)
+        has_user_data = hasattr(request.user, "_me_data")
+        use_auth_header = has_user_data and "xml_export_button" in get_enabled_feature_flags(request.user)
     else:
         use_auth_header = False
     return backend_proxy_view(

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -31,7 +31,7 @@ def case_export_proxy(request):
     is_authenticated = getattr(request.user, "is_authenticated", lambda: False)()
     if is_authenticated:
         is_entra_user = hasattr(request.user, "_me_data")
-        use_auth_header = not is_entra_user or "xml_export_button" in get_enabled_feature_flags(request.user)
+        use_auth_header = is_entra_user and "xml_export_button" in get_enabled_feature_flags(request.user)
     else:
         use_auth_header = False
     return backend_proxy_view(

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -31,7 +31,6 @@ def case_export_proxy(request):
     zone = settings.ZONE_PROFILES.get("cla_provider", {})
     is_entra_user = hasattr(request.user, "_me_data")
     use_auth_header = not is_entra_user or "xml_export_button" in get_enabled_feature_flags(request.user)
-    print("is_entra:", is_entra_user, "use_auth_header:", use_auth_header)
     return backend_proxy_view(
         request,
         path="caseExport/",

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -26,11 +26,14 @@ def get_enabled_feature_flags(user):
 
 
 @csrf_exempt
-@cla_provider_zone_required
 def case_export_proxy(request):
     zone = settings.ZONE_PROFILES.get("cla_provider", {})
-    is_entra_user = hasattr(request.user, "_me_data")
-    use_auth_header = not is_entra_user or "xml_export_button" in get_enabled_feature_flags(request.user)
+    is_authenticated = getattr(request.user, "is_authenticated", lambda: False)()
+    if is_authenticated:
+        is_entra_user = hasattr(request.user, "_me_data")
+        use_auth_header = not is_entra_user or "xml_export_button" in get_enabled_feature_flags(request.user)
+    else:
+        use_auth_header = False
     return backend_proxy_view(
         request,
         path="caseExport/",

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -29,10 +29,13 @@ def get_enabled_feature_flags(user):
 @cla_provider_zone_required
 def case_export_proxy(request):
     zone = settings.ZONE_PROFILES.get("cla_provider", {})
+    is_entra_user = hasattr(request.user, "_me_data")
+    use_auth_header = not is_entra_user or "xml_export_button" in get_enabled_feature_flags(request.user)
+    print("is_entra:", is_entra_user, "use_auth_header:", use_auth_header)
     return backend_proxy_view(
         request,
         path="caseExport/",
-        use_auth_header="xml_export_button" in get_enabled_feature_flags(request.user),
+        use_auth_header=use_auth_header,
         base_remote_url=zone.get("BASE_URI"),
     )
 

--- a/cla_frontend/apps/cla_provider/views.py
+++ b/cla_frontend/apps/cla_provider/views.py
@@ -25,7 +25,7 @@ def get_enabled_feature_flags(user):
     return [name for name, value in flags.items() if value]
 
 # ============================================================================
-# TODO: This proxy view allows legacy user to still use the old XML export flow. 
+# TODO: This proxy view allows legacy user to still use the old XML export flow.
 # Update accordingly once SiLAS is fully implemented and the legacy flow is deprecated.
 # ============================================================================
 


### PR DESCRIPTION
## What does this pull request do?

I'm removing the `@cla_provider_zone_required`  because we found out one of the Providers call the endpoint directly, so without a Django session this is failing for them.

Credentials are still required in POST Body

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"
